### PR TITLE
Finish org rename cleanup, add PR CI, release 0.3.87

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazyide"
-version = "0.3.86"
+version = "0.3.87"
 dependencies = [
  "arboard",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazyide"
-version = "0.3.86"
+version = "0.3.87"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/github/v/release/TysonLabs/lazyide?color=blue&label=version)](https://github.com/TysonLabs/lazyide/releases)
 [![License](https://img.shields.io/github/license/TysonLabs/lazyide)](LICENSE)
-[![CI](https://img.shields.io/github/actions/workflow/status/TysonLabs/lazyide/release.yml?label=build)](https://github.com/TysonLabs/lazyide/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/TysonLabs/lazyide/ci.yml?label=ci)](https://github.com/TysonLabs/lazyide/actions)
 ![Platforms](https://img.shields.io/badge/platforms-linux%20%7C%20macos%20%7C%20windows-brightgreen)
 
 A lightweight terminal IDE built with Rust and [ratatui](https://ratatui.rs). File tree, tabbed editing, LSP, syntax highlighting, code folding, git integration, project search, 32 themes, and customizable keybindings — all in a single binary.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,7 +145,7 @@ cargo test keybind      # tests matching "keybind"
 cargo test syntax       # tests matching "syntax"
 ```
 
-258 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
+272 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
 
 ## Adding a New Feature
 

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -255,11 +255,10 @@ impl App {
             // Dispatch async git refresh if not already in flight
             if !self.git_refresh_in_flight {
                 // Join the previous thread (prevents handle accumulation)
-                if let Some(handle) = self.git_thread_handle.take() {
-                    if handle.join().is_err() {
+                if let Some(handle) = self.git_thread_handle.take()
+                    && handle.join().is_err() {
                         self.set_status("Git refresh thread panicked");
                     }
-                }
                 let root = self.root.clone();
                 let tab_paths: Vec<(PathBuf, usize)> = self
                     .tabs
@@ -557,14 +556,13 @@ impl App {
     }
 
     pub(crate) fn update_status_for_cursor(&mut self) {
-        if self.focus == Focus::Editor {
-            if let Some(tab) = self.active_tab() {
+        if self.focus == Focus::Editor
+            && let Some(tab) = self.active_tab() {
                 let cursor_row = tab.editor.cursor().0;
                 if let Some(diag) = tab.diagnostics.iter().find(|d| d.line == cursor_row + 1) {
                     self.status = format!("[{}] {}", diag.severity, diag.message);
                 }
             }
-        }
     }
 
     pub(crate) fn poll_autosave(&mut self) -> io::Result<()> {
@@ -595,12 +593,11 @@ impl App {
             return;
         };
         let current = self.tabs[self.active_tab].editor.lines().join("\n");
-        if recovered != current {
-            if let Some(tab) = self.active_tab_mut() {
+        if recovered != current
+            && let Some(tab) = self.active_tab_mut() {
                 tab.recovery_prompt_open = true;
                 tab.recovery_text = Some(recovered);
             }
-        }
     }
 
     pub(crate) fn clear_autosave_for_open_file(&mut self) {
@@ -623,12 +620,11 @@ impl App {
             .open_disk_snapshot
             .clone()
             .unwrap_or_default();
-        if disk != snapshot && disk != current {
-            if let Some(tab) = self.active_tab_mut() {
+        if disk != snapshot && disk != current
+            && let Some(tab) = self.active_tab_mut() {
                 tab.conflict_prompt_open = true;
                 tab.conflict_disk_text = Some(disk);
             }
-        }
         Ok(())
     }
     pub(crate) fn clamp_files_pane_width(&mut self, total_width: u16) {
@@ -682,12 +678,12 @@ impl App {
             .reserve(num_lines.saturating_sub(hidden.len()));
         tab.visible_row_ends
             .reserve(num_lines.saturating_sub(hidden.len()));
-        for row in 0..num_lines {
+        for (row, line) in lines.iter().enumerate().take(num_lines) {
             if !hidden.contains(&row) {
                 let segments = if word_wrap {
-                    wrap_segments_for_line(&lines[row], wrap_width)
+                    wrap_segments_for_line(line, wrap_width)
                 } else {
-                    vec![(0, lines[row].chars().count())]
+                    vec![(0, line.chars().count())]
                 };
                 for (start, end) in segments {
                     tab.visible_rows_map.push(row);
@@ -717,12 +713,11 @@ impl App {
     /// Called from the main loop to flush any pending wrap rebuild after a
     /// resize has settled.
     pub(crate) fn poll_wrap_rebuild(&mut self) {
-        if let Some(deadline) = self.wrap_rebuild_deadline {
-            if Instant::now() >= deadline {
+        if let Some(deadline) = self.wrap_rebuild_deadline
+            && Instant::now() >= deadline {
                 self.wrap_rebuild_deadline = None;
                 self.rebuild_all_visible_rows();
             }
-        }
     }
 
     fn editor_wrap_width_chars(&self) -> usize {
@@ -831,15 +826,14 @@ impl App {
         let mut unfolded = false;
         let starts: Vec<usize> = tab.folded_starts.iter().copied().collect();
         for start in starts {
-            if let Some(fr) = tab.fold_ranges.iter().find(|fr| fr.start_line == start) {
-                if fr.start_line == cursor_row
-                    || (fr.start_line <= cursor_row && cursor_row <= fr.end_line)
+            if let Some(fr) = tab.fold_ranges.iter().find(|fr| fr.start_line == start)
+                && (fr.start_line == cursor_row
+                    || (fr.start_line <= cursor_row && cursor_row <= fr.end_line))
                 {
                     self.tabs[self.active_tab].folded_starts.remove(&start);
                     unfolded = true;
                     break;
                 }
-            }
         }
         if unfolded {
             self.rebuild_visible_rows();
@@ -887,14 +881,13 @@ impl App {
         // Check if cursor is on/in a folded block
         let mut is_folded = false;
         for &start in &tab.folded_starts {
-            if let Some(fr) = tab.fold_ranges.iter().find(|fr| fr.start_line == start) {
-                if fr.start_line == cursor_row
-                    || (fr.start_line <= cursor_row && cursor_row <= fr.end_line)
+            if let Some(fr) = tab.fold_ranges.iter().find(|fr| fr.start_line == start)
+                && (fr.start_line == cursor_row
+                    || (fr.start_line <= cursor_row && cursor_row <= fr.end_line))
                 {
                     is_folded = true;
                     break;
                 }
-            }
         }
         if is_folded {
             self.unfold_current_block();

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -23,8 +23,8 @@ use crate::theme::{Theme, load_themes};
 use crate::types::{CommandAction, Focus, PendingAction, PromptMode, PromptState};
 use crate::util::{
     command_action_label, compute_fold_ranges, compute_git_change_summary,
-    compute_git_file_statuses, detect_git_branch, relative_path, spawn_git_refresh,
-    text_to_lines, wrap_segments_for_line,
+    compute_git_file_statuses, detect_git_branch, relative_path, spawn_git_refresh, text_to_lines,
+    wrap_segments_for_line,
 };
 
 impl App {
@@ -256,9 +256,10 @@ impl App {
             if !self.git_refresh_in_flight {
                 // Join the previous thread (prevents handle accumulation)
                 if let Some(handle) = self.git_thread_handle.take()
-                    && handle.join().is_err() {
-                        self.set_status("Git refresh thread panicked");
-                    }
+                    && handle.join().is_err()
+                {
+                    self.set_status("Git refresh thread panicked");
+                }
                 let root = self.root.clone();
                 let tab_paths: Vec<(PathBuf, usize)> = self
                     .tabs
@@ -557,12 +558,13 @@ impl App {
 
     pub(crate) fn update_status_for_cursor(&mut self) {
         if self.focus == Focus::Editor
-            && let Some(tab) = self.active_tab() {
-                let cursor_row = tab.editor.cursor().0;
-                if let Some(diag) = tab.diagnostics.iter().find(|d| d.line == cursor_row + 1) {
-                    self.status = format!("[{}] {}", diag.severity, diag.message);
-                }
+            && let Some(tab) = self.active_tab()
+        {
+            let cursor_row = tab.editor.cursor().0;
+            if let Some(diag) = tab.diagnostics.iter().find(|d| d.line == cursor_row + 1) {
+                self.status = format!("[{}] {}", diag.severity, diag.message);
             }
+        }
     }
 
     pub(crate) fn poll_autosave(&mut self) -> io::Result<()> {
@@ -594,10 +596,11 @@ impl App {
         };
         let current = self.tabs[self.active_tab].editor.lines().join("\n");
         if recovered != current
-            && let Some(tab) = self.active_tab_mut() {
-                tab.recovery_prompt_open = true;
-                tab.recovery_text = Some(recovered);
-            }
+            && let Some(tab) = self.active_tab_mut()
+        {
+            tab.recovery_prompt_open = true;
+            tab.recovery_text = Some(recovered);
+        }
     }
 
     pub(crate) fn clear_autosave_for_open_file(&mut self) {
@@ -620,11 +623,13 @@ impl App {
             .open_disk_snapshot
             .clone()
             .unwrap_or_default();
-        if disk != snapshot && disk != current
-            && let Some(tab) = self.active_tab_mut() {
-                tab.conflict_prompt_open = true;
-                tab.conflict_disk_text = Some(disk);
-            }
+        if disk != snapshot
+            && disk != current
+            && let Some(tab) = self.active_tab_mut()
+        {
+            tab.conflict_prompt_open = true;
+            tab.conflict_disk_text = Some(disk);
+        }
         Ok(())
     }
     pub(crate) fn clamp_files_pane_width(&mut self, total_width: u16) {
@@ -714,10 +719,11 @@ impl App {
     /// resize has settled.
     pub(crate) fn poll_wrap_rebuild(&mut self) {
         if let Some(deadline) = self.wrap_rebuild_deadline
-            && Instant::now() >= deadline {
-                self.wrap_rebuild_deadline = None;
-                self.rebuild_all_visible_rows();
-            }
+            && Instant::now() >= deadline
+        {
+            self.wrap_rebuild_deadline = None;
+            self.rebuild_all_visible_rows();
+        }
     }
 
     fn editor_wrap_width_chars(&self) -> usize {
@@ -829,11 +835,11 @@ impl App {
             if let Some(fr) = tab.fold_ranges.iter().find(|fr| fr.start_line == start)
                 && (fr.start_line == cursor_row
                     || (fr.start_line <= cursor_row && cursor_row <= fr.end_line))
-                {
-                    self.tabs[self.active_tab].folded_starts.remove(&start);
-                    unfolded = true;
-                    break;
-                }
+            {
+                self.tabs[self.active_tab].folded_starts.remove(&start);
+                unfolded = true;
+                break;
+            }
         }
         if unfolded {
             self.rebuild_visible_rows();
@@ -884,10 +890,10 @@ impl App {
             if let Some(fr) = tab.fold_ranges.iter().find(|fr| fr.start_line == start)
                 && (fr.start_line == cursor_row
                     || (fr.start_line <= cursor_row && cursor_row <= fr.end_line))
-                {
-                    is_folded = true;
-                    break;
-                }
+            {
+                is_folded = true;
+                break;
+            }
         }
         if is_folded {
             self.unfold_current_block();
@@ -923,11 +929,7 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let root = tmp.path();
         let file = root.join("test.rs");
-        fs::write(
-            &file,
-            "line 0\nline 1\nline 2\nline 3\nline 4\n",
-        )
-        .expect("write");
+        fs::write(&file, "line 0\nline 1\nline 2\nline 3\nline 4\n").expect("write");
         let mut app = new_app(root);
         app.open_file(file).expect("open");
         app.rebuild_visible_rows();
@@ -940,11 +942,7 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let root = tmp.path();
         let file = root.join("test.rs");
-        fs::write(
-            &file,
-            "fn main() {\n    line 1\n    line 2\n}\nline 4\n",
-        )
-        .expect("write");
+        fs::write(&file, "fn main() {\n    line 1\n    line 2\n}\nline 4\n").expect("write");
         let mut app = new_app(root);
         app.open_file(file).expect("open");
         // Fold the block starting at line 0 (fn main)
@@ -965,11 +963,7 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let root = tmp.path();
         let file = root.join("test.rs");
-        fs::write(
-            &file,
-            "fn a() {\n    body a\n}\nfn b() {\n    body b\n}\n",
-        )
-        .expect("write");
+        fs::write(&file, "fn a() {\n    body a\n}\nfn b() {\n    body b\n}\n").expect("write");
         let mut app = new_app(root);
         app.open_file(file).expect("open");
         // Fold both functions
@@ -1079,7 +1073,10 @@ mod tests {
         let tab = app.active_tab().expect("tab");
         // The long line should produce multiple segments (source row 0 appears more than once)
         let row0_count = tab.visible_rows_map.iter().filter(|&&r| r == 0).count();
-        assert!(row0_count > 1, "long line should wrap into multiple segments");
+        assert!(
+            row0_count > 1,
+            "long line should wrap into multiple segments"
+        );
         // The short line should produce a single segment
         let row1_count = tab.visible_rows_map.iter().filter(|&&r| r == 1).count();
         assert_eq!(row1_count, 1, "short line should be a single segment");
@@ -1179,7 +1176,10 @@ mod tests {
         app.wrap_rebuild_deadline =
             Some(std::time::Instant::now() - std::time::Duration::from_millis(1));
         app.poll_wrap_rebuild();
-        assert!(app.wrap_rebuild_deadline.is_none(), "deadline should be cleared");
+        assert!(
+            app.wrap_rebuild_deadline.is_none(),
+            "deadline should be cleared"
+        );
     }
 
     #[test]

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -283,16 +283,14 @@ impl App {
 
     pub(crate) fn paste_from_clipboard(&mut self) {
         let mut from_system = false;
-        if let Some(clipboard) = self.clipboard.as_mut() {
-            if let Ok(text) = clipboard.get_text() {
-                if !text.is_empty() {
+        if let Some(clipboard) = self.clipboard.as_mut()
+            && let Ok(text) = clipboard.get_text()
+                && !text.is_empty() {
                     if let Some(tab) = self.active_tab_mut() {
                         tab.editor.set_yank_text(text);
                     }
                     from_system = true;
                 }
-            }
-        }
         if self.active_tab_mut().is_some_and(|t| t.editor.paste()) {
             self.on_editor_content_changed();
             if from_system {
@@ -581,20 +579,18 @@ impl App {
             .unwrap_or_default();
         let chars: Vec<char> = line.chars().collect();
         let mut cursor_display_col = 0usize;
-        for i in 0..cursor_col.min(chars.len()) {
-            cursor_display_col +=
-                unicode_width::UnicodeWidthChar::width(chars[i]).unwrap_or(0);
+        for &ch in &chars[..cursor_col.min(chars.len())] {
+            cursor_display_col += unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
         }
         let scroll_col = tab.editor_scroll_col;
         if cursor_display_col < scroll_col {
             if let Some(tab) = self.active_tab_mut() {
                 tab.editor_scroll_col = cursor_display_col;
             }
-        } else if cursor_display_col >= scroll_col + content_width {
-            if let Some(tab) = self.active_tab_mut() {
+        } else if cursor_display_col >= scroll_col + content_width
+            && let Some(tab) = self.active_tab_mut() {
                 tab.editor_scroll_col = cursor_display_col.saturating_sub(content_width.saturating_sub(1));
             }
-        }
     }
 
     /// After a scroll event, ensure the cursor stays within the visible
@@ -777,8 +773,8 @@ impl App {
         };
         let mut col = seg_start;
         let mut width_acc = 0usize;
-        for i in seg_start..seg_end.min(chars.len()) {
-            let cw = unicode_width::UnicodeWidthChar::width(chars[i]).unwrap_or(0);
+        for (i, &ch) in chars.iter().enumerate().take(seg_end.min(chars.len())).skip(seg_start) {
+            let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
             if width_acc + cw > effective_text_x {
                 break;
             }
@@ -869,8 +865,7 @@ impl App {
     pub(crate) fn extend_mouse_selection(&mut self, x: u16, y: u16) {
         if let (Some((anchor_row, anchor_col)), Some((row, col))) =
             (self.editor_drag_anchor, self.editor_pos_from_mouse(x, y))
-        {
-            if let Some(tab) = self.active_tab_mut() {
+            && let Some(tab) = self.active_tab_mut() {
                 tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
                     to_u16_saturating(anchor_row),
                     to_u16_saturating(anchor_col),
@@ -881,7 +876,6 @@ impl App {
                     to_u16_saturating(col),
                 ));
             }
-        }
     }
 }
 

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use ratatui::style::Style;
-use serde_json::json;
 use ratatui_textarea::TextArea;
+use serde_json::json;
 
 use crate::keybinds::{KeyAction, KeyScope};
 use crate::persistence::autosave_path_for;
@@ -211,14 +211,18 @@ impl App {
             ));
         } else if total_lines == 1 {
             // Only one line: select all text on it
-            tab.editor
-                .move_cursor(ratatui_textarea::CursorMove::Jump(to_u16_saturating(row), 0));
+            tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
+                to_u16_saturating(row),
+                0,
+            ));
             tab.editor.start_selection();
             tab.editor.move_cursor(ratatui_textarea::CursorMove::End);
         } else {
             // Select from start of this line to start of next line
-            tab.editor
-                .move_cursor(ratatui_textarea::CursorMove::Jump(to_u16_saturating(row), 0));
+            tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
+                to_u16_saturating(row),
+                0,
+            ));
             tab.editor.start_selection();
             tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
                 to_u16_saturating(row + 1),
@@ -231,9 +235,7 @@ impl App {
         if let Some(clipboard) = self.clipboard.as_mut() {
             let _ = clipboard.set_text(line_text.clone());
         }
-        self.tabs[self.active_tab]
-            .editor
-            .set_yank_text(line_text);
+        self.tabs[self.active_tab].editor.set_yank_text(line_text);
         self.on_editor_content_changed();
         self.set_status("Cut line");
     }
@@ -285,12 +287,13 @@ impl App {
         let mut from_system = false;
         if let Some(clipboard) = self.clipboard.as_mut()
             && let Ok(text) = clipboard.get_text()
-                && !text.is_empty() {
-                    if let Some(tab) = self.active_tab_mut() {
-                        tab.editor.set_yank_text(text);
-                    }
-                    from_system = true;
-                }
+            && !text.is_empty()
+        {
+            if let Some(tab) = self.active_tab_mut() {
+                tab.editor.set_yank_text(text);
+            }
+            from_system = true;
+        }
         if self.active_tab_mut().is_some_and(|t| t.editor.paste()) {
             self.on_editor_content_changed();
             if from_system {
@@ -588,9 +591,11 @@ impl App {
                 tab.editor_scroll_col = cursor_display_col;
             }
         } else if cursor_display_col >= scroll_col + content_width
-            && let Some(tab) = self.active_tab_mut() {
-                tab.editor_scroll_col = cursor_display_col.saturating_sub(content_width.saturating_sub(1));
-            }
+            && let Some(tab) = self.active_tab_mut()
+        {
+            tab.editor_scroll_col =
+                cursor_display_col.saturating_sub(content_width.saturating_sub(1));
+        }
     }
 
     /// After a scroll event, ensure the cursor stays within the visible
@@ -773,7 +778,12 @@ impl App {
         };
         let mut col = seg_start;
         let mut width_acc = 0usize;
-        for (i, &ch) in chars.iter().enumerate().take(seg_end.min(chars.len())).skip(seg_start) {
+        for (i, &ch) in chars
+            .iter()
+            .enumerate()
+            .take(seg_end.min(chars.len()))
+            .skip(seg_start)
+        {
             let cw = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
             if width_acc + cw > effective_text_x {
                 break;
@@ -836,11 +846,7 @@ impl App {
                     0,
                 ));
             } else {
-                let line_len = tab
-                    .editor
-                    .lines()
-                    .get(end)
-                    .map_or(0, |l| l.chars().count());
+                let line_len = tab.editor.lines().get(end).map_or(0, |l| l.chars().count());
                 tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
                     to_u16_saturating(end),
                     to_u16_saturating(line_len),
@@ -865,17 +871,18 @@ impl App {
     pub(crate) fn extend_mouse_selection(&mut self, x: u16, y: u16) {
         if let (Some((anchor_row, anchor_col)), Some((row, col))) =
             (self.editor_drag_anchor, self.editor_pos_from_mouse(x, y))
-            && let Some(tab) = self.active_tab_mut() {
-                tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
-                    to_u16_saturating(anchor_row),
-                    to_u16_saturating(anchor_col),
-                ));
-                tab.editor.start_selection();
-                tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
-                    to_u16_saturating(row),
-                    to_u16_saturating(col),
-                ));
-            }
+            && let Some(tab) = self.active_tab_mut()
+        {
+            tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
+                to_u16_saturating(anchor_row),
+                to_u16_saturating(anchor_col),
+            ));
+            tab.editor.start_selection();
+            tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(
+                to_u16_saturating(row),
+                to_u16_saturating(col),
+            ));
+        }
     }
 }
 

--- a/src/app/file_tree.rs
+++ b/src/app/file_tree.rs
@@ -240,11 +240,10 @@ impl App {
             let _ = self.rebuild_tree();
             return;
         }
-        if let Some(parent) = item.path.parent() {
-            if let Some(idx) = self.tree.iter().position(|i| i.path == parent) {
+        if let Some(parent) = item.path.parent()
+            && let Some(idx) = self.tree.iter().position(|i| i.path == parent) {
                 self.selected = idx;
             }
-        }
     }
 
     pub(crate) fn tree_expand_recursive(&mut self) -> io::Result<()> {

--- a/src/app/file_tree.rs
+++ b/src/app/file_tree.rs
@@ -241,9 +241,10 @@ impl App {
             return;
         }
         if let Some(parent) = item.path.parent()
-            && let Some(idx) = self.tree.iter().position(|i| i.path == parent) {
-                self.selected = idx;
-            }
+            && let Some(idx) = self.tree.iter().position(|i| i.path == parent)
+        {
+            self.selected = idx;
+        }
     }
 
     pub(crate) fn tree_expand_recursive(&mut self) -> io::Result<()> {
@@ -719,10 +720,11 @@ mod tests {
         );
         assert!(app.cached_file_list.iter().any(|p| p.ends_with("a.rs")));
         assert!(app.cached_file_list.iter().any(|p| p.ends_with("b.rs")));
-        assert!(app
-            .cached_file_list
-            .iter()
-            .any(|p| p.ends_with("src/c.rs") || p.ends_with("src\\c.rs")));
+        assert!(
+            app.cached_file_list
+                .iter()
+                .any(|p| p.ends_with("src/c.rs") || p.ends_with("src\\c.rs"))
+        );
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -89,21 +89,19 @@ impl App {
                     return Ok(());
                 }
             }
-            (KeyModifiers::NONE, KeyCode::Delete) => {
-                if self.focus == Focus::Tree {
-                    if let Some(item) = self.selected_item().cloned() {
-                        if item.path == self.root {
-                            self.set_status("Cannot delete project root");
-                            return Ok(());
-                        }
-                        self.pending = PendingAction::Delete(item.path.clone());
-                        self.set_status(format!(
-                            "Delete {} ? Press Enter to confirm, Esc to cancel.",
-                            item.name,
-                        ));
+            (KeyModifiers::NONE, KeyCode::Delete) if self.focus == Focus::Tree => {
+                if let Some(item) = self.selected_item().cloned() {
+                    if item.path == self.root {
+                        self.set_status("Cannot delete project root");
+                        return Ok(());
                     }
-                    return Ok(());
+                    self.pending = PendingAction::Delete(item.path.clone());
+                    self.set_status(format!(
+                        "Delete {} ? Press Enter to confirm, Esc to cancel.",
+                        item.name,
+                    ));
                 }
+                return Ok(());
             }
             _ => {}
         }
@@ -202,13 +200,11 @@ impl App {
                         return Ok(());
                     }
                 }
-                MouseEventKind::Up(MouseButton::Left) => {
-                    if self.divider_dragging {
-                        self.divider_dragging = false;
-                        self.persist_state();
-                        self.set_status(format!("Files pane width: {}", self.files_pane_width));
-                        return Ok(());
-                    }
+                MouseEventKind::Up(MouseButton::Left) if self.divider_dragging => {
+                    self.divider_dragging = false;
+                    self.persist_state();
+                    self.set_status(format!("Files pane width: {}", self.files_pane_width));
+                    return Ok(());
                 }
                 _ => {}
             }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -405,8 +405,8 @@ impl App {
                     return Ok(());
                 }
                 MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
-                    if !self.word_wrap {
-                        if let Some(tab) = self.active_tab_mut() {
+                    if !self.word_wrap
+                        && let Some(tab) = self.active_tab_mut() {
                             match mouse.kind {
                                 MouseEventKind::ScrollLeft => {
                                     tab.editor_scroll_col = tab
@@ -421,7 +421,6 @@ impl App {
                                 _ => {}
                             }
                         }
-                    }
                     return Ok(());
                 }
                 _ => return Ok(()),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -133,11 +133,8 @@ impl App {
         {
             if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
                 // If prompt is open and click is inside the input area, move cursor
-                if self.prompt.is_some()
-                    && inside(mouse.column, mouse.row, self.prompt_rect)
-                {
-                    let inner_x =
-                        mouse.column.saturating_sub(self.prompt_rect.x + 1) as usize;
+                if self.prompt.is_some() && inside(mouse.column, mouse.row, self.prompt_rect) {
+                    let inner_x = mouse.column.saturating_sub(self.prompt_rect.x + 1) as usize;
                     if let Some(prompt) = self.prompt.as_mut() {
                         prompt.cursor = inner_x.min(prompt.value.len());
                     }
@@ -257,8 +254,8 @@ impl App {
                     self.open_tree_context_menu_at(mouse.column, mouse.row);
                 }
                 MouseEventKind::ScrollDown => {
-                    self.selected = (self.selected + Self::SCROLL_LINES)
-                        .min(self.tree.len().saturating_sub(1));
+                    self.selected =
+                        (self.selected + Self::SCROLL_LINES).min(self.tree.len().saturating_sub(1));
                 }
                 MouseEventKind::ScrollUp => {
                     self.selected = self.selected.saturating_sub(Self::SCROLL_LINES);
@@ -379,10 +376,8 @@ impl App {
                     }
                     let viewport_h = self.editor_rect.height.saturating_sub(2) as usize;
                     if let Some(tab) = self.active_tab_mut() {
-                        let max_scroll = tab
-                            .visible_rows_map
-                            .len()
-                            .saturating_sub(viewport_h.max(1));
+                        let max_scroll =
+                            tab.visible_rows_map.len().saturating_sub(viewport_h.max(1));
                         match mouse.kind {
                             MouseEventKind::ScrollDown => {
                                 tab.editor_scroll_row = tab
@@ -391,9 +386,8 @@ impl App {
                                     .min(max_scroll)
                             }
                             MouseEventKind::ScrollUp => {
-                                tab.editor_scroll_row = tab
-                                    .editor_scroll_row
-                                    .saturating_sub(Self::SCROLL_LINES)
+                                tab.editor_scroll_row =
+                                    tab.editor_scroll_row.saturating_sub(Self::SCROLL_LINES)
                             }
                             _ => {}
                         }
@@ -406,21 +400,20 @@ impl App {
                 }
                 MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
                     if !self.word_wrap
-                        && let Some(tab) = self.active_tab_mut() {
-                            match mouse.kind {
-                                MouseEventKind::ScrollLeft => {
-                                    tab.editor_scroll_col = tab
-                                        .editor_scroll_col
-                                        .saturating_sub(Self::SCROLL_LINES);
-                                }
-                                MouseEventKind::ScrollRight => {
-                                    tab.editor_scroll_col = tab
-                                        .editor_scroll_col
-                                        .saturating_add(Self::SCROLL_LINES);
-                                }
-                                _ => {}
+                        && let Some(tab) = self.active_tab_mut()
+                    {
+                        match mouse.kind {
+                            MouseEventKind::ScrollLeft => {
+                                tab.editor_scroll_col =
+                                    tab.editor_scroll_col.saturating_sub(Self::SCROLL_LINES);
                             }
+                            MouseEventKind::ScrollRight => {
+                                tab.editor_scroll_col =
+                                    tab.editor_scroll_col.saturating_add(Self::SCROLL_LINES);
+                            }
+                            _ => {}
                         }
+                    }
                     return Ok(());
                 }
                 _ => return Ok(()),

--- a/src/app/input_handlers.rs
+++ b/src/app/input_handlers.rs
@@ -84,11 +84,9 @@ impl App {
             (_, KeyCode::End) => {
                 prompt.cursor = prompt.value.len();
             }
-            (_, KeyCode::Char(c)) => {
-                if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                    prompt.value.insert(prompt.cursor, c);
-                    prompt.cursor += 1;
-                }
+            (_, KeyCode::Char(c)) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                prompt.value.insert(prompt.cursor, c);
+                prompt.cursor += 1;
             }
             _ => {}
         }
@@ -120,14 +118,13 @@ impl App {
                 self.file_picker_index = 0;
                 self.refresh_file_picker_results();
             }
-            (_, KeyCode::Char(c)) => {
+            (_, KeyCode::Char(c))
                 if !key.modifiers.contains(KeyModifiers::CONTROL)
-                    && !key.modifiers.contains(KeyModifiers::ALT)
-                {
-                    self.file_picker_query.push(c);
-                    self.file_picker_index = 0;
-                    self.refresh_file_picker_results();
-                }
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.file_picker_query.push(c);
+                self.file_picker_index = 0;
+                self.refresh_file_picker_results();
             }
             _ => {}
         }
@@ -730,13 +727,12 @@ impl App {
                 self.keybind_editor.query.pop();
                 self.refresh_keybind_editor_actions();
             }
-            (_, KeyCode::Char(c)) => {
+            (_, KeyCode::Char(c))
                 if !key.modifiers.contains(KeyModifiers::CONTROL)
-                    && !key.modifiers.contains(KeyModifiers::ALT)
-                {
-                    self.keybind_editor.query.push(c);
-                    self.refresh_keybind_editor_actions();
-                }
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.keybind_editor.query.push(c);
+                self.refresh_keybind_editor_actions();
             }
             _ => {}
         }
@@ -786,13 +782,12 @@ impl App {
                 self.menu_query.pop();
                 self.refresh_menu_results();
             }
-            (_, KeyCode::Char(c)) => {
+            (_, KeyCode::Char(c))
                 if !key.modifiers.contains(KeyModifiers::CONTROL)
-                    && !key.modifiers.contains(KeyModifiers::ALT)
-                {
-                    self.menu_query.push(c);
-                    self.refresh_menu_results();
-                }
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.menu_query.push(c);
+                self.refresh_menu_results();
             }
             _ => {}
         }

--- a/src/app/input_handlers.rs
+++ b/src/app/input_handlers.rs
@@ -582,7 +582,8 @@ impl App {
             KeyAction::PageUp => self.page_up(),
             KeyAction::GoToStart => {
                 if let Some(tab) = self.active_tab_mut() {
-                    tab.editor.move_cursor(ratatui_textarea::CursorMove::Jump(0, 0));
+                    tab.editor
+                        .move_cursor(ratatui_textarea::CursorMove::Jump(0, 0));
                 }
                 self.sync_editor_scroll_guess();
                 self.set_status("Top of file");

--- a/src/app/lsp.rs
+++ b/src/app/lsp.rs
@@ -76,11 +76,10 @@ impl App {
                 .and_then(|s| s.get("character"))
                 .and_then(Value::as_u64)
                 .unwrap_or(0) as usize;
-            if let Ok(url) = Url::parse(uri) {
-                if let Ok(path) = url.to_file_path() {
+            if let Ok(url) = Url::parse(uri)
+                && let Ok(path) = url.to_file_path() {
                     target = Some((path, line, col));
                 }
-            }
         }
         let Some((path, line, col)) = target else {
             if self.try_local_definition_jump() {
@@ -553,13 +552,12 @@ impl App {
         };
         let insert = item.insert_text.unwrap_or_else(|| item.label.clone());
         let prefix = self.current_identifier_prefix();
-        if !prefix.is_empty() {
-            if let Some(tab) = self.active_tab_mut() {
+        if !prefix.is_empty()
+            && let Some(tab) = self.active_tab_mut() {
                 for _ in 0..prefix.chars().count() {
                     let _ = tab.editor.delete_char();
                 }
             }
-        }
         let inserted = self
             .active_tab_mut()
             .is_some_and(|t| t.editor.insert_str(insert));

--- a/src/app/lsp.rs
+++ b/src/app/lsp.rs
@@ -77,9 +77,10 @@ impl App {
                 .and_then(Value::as_u64)
                 .unwrap_or(0) as usize;
             if let Ok(url) = Url::parse(uri)
-                && let Ok(path) = url.to_file_path() {
-                    target = Some((path, line, col));
-                }
+                && let Ok(path) = url.to_file_path()
+            {
+                target = Some((path, line, col));
+            }
         }
         let Some((path, line, col)) = target else {
             if self.try_local_definition_jump() {
@@ -553,11 +554,12 @@ impl App {
         let insert = item.insert_text.unwrap_or_else(|| item.label.clone());
         let prefix = self.current_identifier_prefix();
         if !prefix.is_empty()
-            && let Some(tab) = self.active_tab_mut() {
-                for _ in 0..prefix.chars().count() {
-                    let _ = tab.editor.delete_char();
-                }
+            && let Some(tab) = self.active_tab_mut()
+        {
+            for _ in 0..prefix.chars().count() {
+                let _ = tab.editor.delete_char();
             }
+        }
         let inserted = self
             .active_tab_mut()
             .is_some_and(|t| t.editor.insert_str(insert));

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -662,13 +662,15 @@ pub(crate) enum SingleOrVec {
 
 fn keybinds_file_path() -> Option<PathBuf> {
     if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
-        && !xdg.is_empty() {
-            return Some(PathBuf::from(xdg).join(KEYBINDS_FILE_REL));
-        }
+        && !xdg.is_empty()
+    {
+        return Some(PathBuf::from(xdg).join(KEYBINDS_FILE_REL));
+    }
     if let Ok(appdata) = std::env::var("APPDATA")
-        && !appdata.is_empty() {
-            return Some(PathBuf::from(appdata).join(KEYBINDS_FILE_REL));
-        }
+        && !appdata.is_empty()
+    {
+        return Some(PathBuf::from(appdata).join(KEYBINDS_FILE_REL));
+    }
     std::env::var("HOME")
         .ok()
         .map(|home| PathBuf::from(home).join(".config").join(KEYBINDS_FILE_REL))

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -661,16 +661,14 @@ pub(crate) enum SingleOrVec {
 }
 
 fn keybinds_file_path() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-        if !xdg.is_empty() {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty() {
             return Some(PathBuf::from(xdg).join(KEYBINDS_FILE_REL));
         }
-    }
-    if let Ok(appdata) = std::env::var("APPDATA") {
-        if !appdata.is_empty() {
+    if let Ok(appdata) = std::env::var("APPDATA")
+        && !appdata.is_empty() {
             return Some(PathBuf::from(appdata).join(KEYBINDS_FILE_REL));
         }
-    }
     std::env::var("HOME")
         .ok()
         .map(|home| PathBuf::from(home).join(".config").join(KEYBINDS_FILE_REL))

--- a/src/lsp_client.rs
+++ b/src/lsp_client.rs
@@ -220,12 +220,12 @@ mod lsp_and_struct_tests {
     use crate::tab::{FoldRange, Tab};
     use crate::tree_item::TreeItem;
     use crate::util::file_uri;
+    use ratatui_textarea::TextArea;
     use serde_json::json;
     use std::collections::HashSet;
     use std::io::Cursor;
     use std::path::PathBuf;
     use std::sync::mpsc;
-    use ratatui_textarea::TextArea;
 
     #[test]
     fn test_lsp_reader_loop_valid_notification() {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -73,9 +73,8 @@ fn rgb_to_256(r: u8, g: u8, b: u8) -> Color {
     let cube_r = ri as i32 * 255 / 5;
     let cube_g = gi as i32 * 255 / 5;
     let cube_b = bi as i32 * 255 / 5;
-    let cube_dist = (r as i32 - cube_r).pow(2)
-        + (g as i32 - cube_g).pow(2)
-        + (b as i32 - cube_b).pow(2);
+    let cube_dist =
+        (r as i32 - cube_r).pow(2) + (g as i32 - cube_g).pow(2) + (b as i32 - cube_b).pow(2);
 
     let gray_val = if gray_idx == 232 {
         8
@@ -84,9 +83,8 @@ fn rgb_to_256(r: u8, g: u8, b: u8) -> Color {
     } else {
         8 + (gray_idx - 232) as i32 * 247 / 24 + 247 / 48
     };
-    let gray_dist = (r as i32 - gray_val).pow(2)
-        + (g as i32 - gray_val).pow(2)
-        + (b as i32 - gray_val).pow(2);
+    let gray_dist =
+        (r as i32 - gray_val).pow(2) + (g as i32 - gray_val).pow(2) + (b as i32 - gray_val).pow(2);
 
     if gray_dist < cube_dist {
         Color::Indexed(gray_idx)

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -353,10 +353,7 @@ mod selection_span_tests {
     fn test_select_across_multiple_spans() {
         let kw = Style::default().fg(Color::Blue);
         let plain = Style::default();
-        let spans = vec![
-            Span::styled("fn ", kw),
-            Span::styled("main()", plain),
-        ];
+        let spans = vec![Span::styled("fn ", kw), Span::styled("main()", plain)];
         // Select "n main" (columns 1..7)
         let result = apply_selection_to_spans(spans, 1, 7, sel_style());
         assert_eq!(collect_text(&result), "fn main()");

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -171,10 +171,7 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                 Span::styled("[+]", Style::default().fg(theme.accent)),
                 Span::styled("[-]", Style::default().fg(theme.accent)),
             ]));
-            frame.render_widget(
-                btns,
-                Rect::new(btn_x, btn_y, btn_width, 1),
-            );
+            frame.render_widget(btns, Rect::new(btn_x, btn_y, btn_width, 1));
         }
         if app.files_view_open && app.divider_rect.width > 0 {
             let divider =
@@ -657,24 +654,23 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                 // cursor off-screen — don't render
             } else if let Some(ghost) = app.completion.ghost.as_ref()
                 && !ghost.is_empty()
-                    && (cursor_x as u16 + App::EDITOR_GUTTER_WIDTH) < inner.width.saturating_sub(1)
-                {
-                    let ghost_area = Rect::new(
-                        inner
-                            .x
-                            .saturating_add(App::EDITOR_GUTTER_WIDTH)
-                            .saturating_add(cursor_x as u16),
-                        inner.y.saturating_add(cursor_y as u16),
-                        inner
-                            .width
-                            .saturating_sub(App::EDITOR_GUTTER_WIDTH)
-                            .saturating_sub(cursor_x as u16),
-                        1,
-                    );
-                    let ghost_span =
-                        Span::styled(ghost.clone(), Style::default().fg(theme.fg_muted));
-                    frame.render_widget(Paragraph::new(Line::from(vec![ghost_span])), ghost_area);
-                }
+                && (cursor_x as u16 + App::EDITOR_GUTTER_WIDTH) < inner.width.saturating_sub(1)
+            {
+                let ghost_area = Rect::new(
+                    inner
+                        .x
+                        .saturating_add(App::EDITOR_GUTTER_WIDTH)
+                        .saturating_add(cursor_x as u16),
+                    inner.y.saturating_add(cursor_y as u16),
+                    inner
+                        .width
+                        .saturating_sub(App::EDITOR_GUTTER_WIDTH)
+                        .saturating_sub(cursor_x as u16),
+                    1,
+                );
+                let ghost_span = Span::styled(ghost.clone(), Style::default().fg(theme.fg_muted));
+                frame.render_widget(Paragraph::new(Line::from(vec![ghost_span])), ghost_area);
+            }
             frame.set_cursor_position((
                 inner
                     .x

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -644,8 +644,8 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                     .map(|l| l.replace('\t', "    ").chars().collect())
                     .unwrap_or_default();
                 let mut dw = 0usize;
-                for i in 0..cursor_col.min(line_chars.len()) {
-                    dw += unicode_width::UnicodeWidthChar::width(line_chars[i]).unwrap_or(0);
+                for &ch in &line_chars[..cursor_col.min(line_chars.len())] {
+                    dw += unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
                 }
                 dw.saturating_sub(scroll_col)
             } else {
@@ -655,9 +655,8 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
             // If cursor would be off-screen horizontally (scrolled past), skip rendering
             if !app.word_wrap && cursor_x > max_x {
                 // cursor off-screen — don't render
-            } else
-            if let Some(ghost) = app.completion.ghost.as_ref() {
-                if !ghost.is_empty()
+            } else if let Some(ghost) = app.completion.ghost.as_ref()
+                && !ghost.is_empty()
                     && (cursor_x as u16 + App::EDITOR_GUTTER_WIDTH) < inner.width.saturating_sub(1)
                 {
                     let ghost_area = Rect::new(
@@ -676,7 +675,6 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                         Span::styled(ghost.clone(), Style::default().fg(theme.fg_muted));
                     frame.render_widget(Paragraph::new(Line::from(vec![ghost_span])), ghost_area);
                 }
-            }
             frame.set_cursor_position((
                 inner
                     .x

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -491,8 +491,14 @@ pub(crate) fn render_help(app: &mut App, frame: &mut Frame<'_>) {
         ),
         help_keybind_line(
             &[
-                (&kb.display_for(KeyAction::TreeExpandRecursive), "expand recursive"),
-                (&kb.display_for(KeyAction::TreeCollapseRecursive), "collapse recursive"),
+                (
+                    &kb.display_for(KeyAction::TreeExpandRecursive),
+                    "expand recursive",
+                ),
+                (
+                    &kb.display_for(KeyAction::TreeCollapseRecursive),
+                    "collapse recursive",
+                ),
             ],
             key_s,
             desc_s,
@@ -654,11 +660,13 @@ fn render_dialog(
 pub(crate) fn render_close_prompt(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme();
     let area = centered_rect(60, 26, frame.area());
-    let text = ["Unsaved changes".to_string(),
+    let text = [
+        "Unsaved changes".to_string(),
         "".to_string(),
         format!("Enter or {}+S: Save and close", primary_mod_label()),
         "Esc: Discard and close".to_string(),
-        "C: Cancel".to_string()]
+        "C: Cancel".to_string(),
+    ]
     .join("\n");
     render_dialog(area, "Close File", text, theme, frame);
 }

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -654,13 +654,11 @@ fn render_dialog(
 pub(crate) fn render_close_prompt(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme();
     let area = centered_rect(60, 26, frame.area());
-    let text = vec![
-        "Unsaved changes".to_string(),
+    let text = ["Unsaved changes".to_string(),
         "".to_string(),
         format!("Enter or {}+S: Save and close", primary_mod_label()),
         "Esc: Discard and close".to_string(),
-        "C: Cancel".to_string(),
-    ]
+        "C: Cancel".to_string()]
     .join("\n");
     render_dialog(area, "Close File", text, theme, frame);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1342,7 +1342,7 @@ mod fold_and_selection_tests {
     fn test_visible_rows_map_excludes_folded_lines() {
         // Simulate a 7-line file with lines 1-2 folded (fold starting at line 0)
         let lines: Vec<String> = (0..7).map(|i| format!("line {i}")).collect();
-        let fold_ranges = vec![FoldRange {
+        let fold_ranges = [FoldRange {
             start_line: 0,
             end_line: 2,
         }];
@@ -1779,7 +1779,7 @@ mod indent_depth_tests {
     #[test]
     fn test_blank_line_depth_propagation_simple() {
         // Simulate the two-pass algorithm from draw()
-        let lines = vec!["    a", "", "    b"];
+        let lines = ["    a", "", "    b"];
         let total = lines.len();
         let mut depths = vec![0usize; total];
         let mut is_blank = vec![false; total];
@@ -1819,7 +1819,7 @@ mod indent_depth_tests {
     #[test]
     fn test_blank_line_depth_min_of_neighbors() {
         // Blank line between different depths picks the minimum
-        let lines = vec!["        a", "", "    b"];
+        let lines = ["        a", "", "    b"];
         let total = lines.len();
         let mut depths = vec![0usize; total];
         let mut is_blank = vec![false; total];
@@ -1860,7 +1860,7 @@ mod indent_depth_tests {
 
     #[test]
     fn test_consecutive_blank_lines_propagate() {
-        let lines = vec!["    a", "", "", "", "    b"];
+        let lines = ["    a", "", "", "", "    b"];
         let total = lines.len();
         let mut depths = vec![0usize; total];
         let mut is_blank = vec![false; total];
@@ -1900,7 +1900,7 @@ mod indent_depth_tests {
 
     #[test]
     fn test_blank_lines_at_start_use_below() {
-        let lines = vec!["", "", "    code"];
+        let lines = ["", "", "    code"];
         let total = lines.len();
         let mut depths = vec![0usize; total];
         let mut is_blank = vec![false; total];
@@ -1940,7 +1940,7 @@ mod indent_depth_tests {
 
     #[test]
     fn test_no_blank_lines() {
-        let lines = vec!["a", "    b", "        c"];
+        let lines = ["a", "    b", "        c"];
         let total = lines.len();
         let mut depths = vec![0usize; total];
         let mut is_blank = vec![false; total];

--- a/src/util.rs
+++ b/src/util.rs
@@ -257,14 +257,13 @@ fn parse_unified_diff_into(diff: &str, result: &mut [GitLineStatus]) {
             if let Some(plus_part) = line.split('+').nth(1) {
                 let nums: &str = plus_part.split_whitespace().next().unwrap_or("");
                 let mut parts = nums.split(',');
-                if let Some(start_str) = parts.next() {
-                    if let Ok(start) = start_str.parse::<usize>() {
+                if let Some(start_str) = parts.next()
+                    && let Ok(start) = start_str.parse::<usize>() {
                         new_line = start;
                         let _count: usize = parts.next().and_then(|n| n.parse().ok()).unwrap_or(1);
                         in_hunk = true;
                         pending_deletes = 0;
                     }
-                }
             }
             continue;
         }
@@ -498,16 +497,14 @@ pub(crate) fn compute_fold_ranges(
                     depth = depth.saturating_add(1);
                 } else if ch == '}' || ch == ')' || ch == ']' {
                     depth = depth.saturating_sub(1);
-                    if ch == '}' {
-                        if let Some((_, start)) = stack.pop() {
-                            if row > start {
+                    if ch == '}'
+                        && let Some((_, start)) = stack.pop()
+                            && row > start {
                                 ranges.push(FoldRange {
                                     start_line: start,
                                     end_line: row,
                                 });
                             }
-                        }
-                    }
                 }
             } else if ch == '\\' {
                 i += 2;
@@ -656,8 +653,8 @@ pub(crate) fn wrap_segments_for_line(line: &str, wrap_width: usize) -> Vec<(usiz
         let start_w = cum_width[start];
         // Find the furthest char index whose display width fits within wrap_width.
         let mut hard_end = start;
-        for i in (start + 1)..=len {
-            if cum_width[i] - start_w > wrap_width {
+        for (i, &w) in cum_width.iter().enumerate().skip(start + 1) {
+            if w - start_w > wrap_width {
                 break;
             }
             hard_end = i;

--- a/src/util.rs
+++ b/src/util.rs
@@ -258,12 +258,13 @@ fn parse_unified_diff_into(diff: &str, result: &mut [GitLineStatus]) {
                 let nums: &str = plus_part.split_whitespace().next().unwrap_or("");
                 let mut parts = nums.split(',');
                 if let Some(start_str) = parts.next()
-                    && let Ok(start) = start_str.parse::<usize>() {
-                        new_line = start;
-                        let _count: usize = parts.next().and_then(|n| n.parse().ok()).unwrap_or(1);
-                        in_hunk = true;
-                        pending_deletes = 0;
-                    }
+                    && let Ok(start) = start_str.parse::<usize>()
+                {
+                    new_line = start;
+                    let _count: usize = parts.next().and_then(|n| n.parse().ok()).unwrap_or(1);
+                    in_hunk = true;
+                    pending_deletes = 0;
+                }
             }
             continue;
         }
@@ -499,12 +500,13 @@ pub(crate) fn compute_fold_ranges(
                     depth = depth.saturating_sub(1);
                     if ch == '}'
                         && let Some((_, start)) = stack.pop()
-                            && row > start {
-                                ranges.push(FoldRange {
-                                    start_line: start,
-                                    end_line: row,
-                                });
-                            }
+                        && row > start
+                    {
+                        ranges.push(FoldRange {
+                            start_line: start,
+                            end_line: row,
+                        });
+                    }
                 }
             } else if ch == '\\' {
                 i += 2;
@@ -1749,11 +1751,7 @@ mod async_git_tests {
         let fake_file = tmp.path().join("test.rs");
         std::fs::write(&fake_file, "fn main() {}\n").expect("write");
         let (tx, rx) = mpsc::channel();
-        spawn_git_refresh(
-            tmp.path().to_path_buf(),
-            vec![(fake_file.clone(), 1)],
-            tx,
-        );
+        spawn_git_refresh(tmp.path().to_path_buf(), vec![(fake_file.clone(), 1)], tx);
         let result = rx
             .recv_timeout(Duration::from_secs(5))
             .expect("should receive GitResult");


### PR DESCRIPTION
## Summary
- Fix all 28 clippy warnings (mechanical: collapsed ifs, iterator loops, needless `vec!`)
- One-time repo-wide `cargo fmt` (separate commit, no logic changes) so CI can enforce rustfmt
- New `ci.yml`: fmt check, clippy `-D warnings`, tests on PRs and pushes to main
- README build badge now tracks CI instead of the release workflow
- ARCHITECTURE.md test count 258 -> 272
- Bump to 0.3.87. Merging triggers auto-tag + release, which also rewrites the Homebrew formula URLs that still point at `tgeorge06/lazyide` after the org move.

## Review
Tier 1. Local gate green (fmt, clippy all-targets -D warnings, 272 tests). Codex adversarial review: CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)