### PR TITLE
Add Move to... action to the file tree context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ After installing, run `lazyide --setup` to detect and install optional tools (ru
 
 - Click file/folder in tree to open
 - Drag divider to resize panes
-- Right-click tree for context menu (New File, Rename, Delete)
+- Right-click tree for context menu (New File, New Folder, Rename, Move to, Delete)
 - Click + drag in editor to select text
 - Right-click editor for edit menu
 - Click gutter fold icons to toggle folds

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,7 +145,7 @@ cargo test keybind      # tests matching "keybind"
 cargo test syntax       # tests matching "syntax"
 ```
 
-272 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
+275 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
 
 ## Adding a New Feature
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,7 +145,7 @@ cargo test keybind      # tests matching "keybind"
 cargo test syntax       # tests matching "syntax"
 ```
 
-275 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
+276 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
 
 ## Adding a New Feature
 

--- a/src/app/file_tree.rs
+++ b/src/app/file_tree.rs
@@ -5,7 +5,9 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::tree_item::TreeItem;
 use crate::types::{ContextAction, PendingAction, PromptMode, PromptState};
-use crate::util::{collect_all_files, fuzzy_score, relative_path, to_u16_saturating};
+use crate::util::{
+    collect_all_files, fuzzy_score, normalize_lexically, relative_path, to_u16_saturating,
+};
 
 impl App {
     fn sanitize_entry_name<'a>(&self, value: &'a str) -> Result<&'a str, &'static str> {
@@ -22,7 +24,9 @@ impl App {
 
     /// Resolve the user-entered destination folder for a move. Relative paths
     /// are taken from the project root; absolute paths are allowed so items can
-    /// leave the project. Returns the canonical destination directory.
+    /// leave the project. The returned path is lexically normalized but NOT
+    /// canonicalized, so it stays comparable with `self.root` and tree paths
+    /// (the root itself may sit behind a symlink, e.g. macOS `/var`).
     fn resolve_move_destination(&self, target: &Path, value: &str) -> Result<PathBuf, String> {
         let trimmed = value.trim();
         let raw = if trimmed.is_empty() || trimmed == "." {
@@ -30,22 +34,26 @@ impl App {
         } else {
             self.root.join(trimmed)
         };
-        let dest = raw
-            .canonicalize()
-            .map_err(|_| "Destination folder does not exist".to_string())?;
+        let dest = normalize_lexically(&raw);
         if !dest.is_dir() {
-            return Err("Destination is not a folder".to_string());
+            return Err(if dest.exists() {
+                "Destination is not a folder".to_string()
+            } else {
+                "Destination folder does not exist".to_string()
+            });
         }
+        // Canonical forms are used only for identity comparisons.
+        let dest_canon = dest.canonicalize().unwrap_or_else(|_| dest.clone());
         let current_parent = target
             .parent()
             .and_then(|p| p.canonicalize().ok())
             .unwrap_or_else(|| self.root.clone());
-        if dest == current_parent {
+        if dest_canon == current_parent {
             return Err("Already in that folder".to_string());
         }
         if target.is_dir()
             && let Ok(target_canon) = target.canonicalize()
-            && dest.starts_with(&target_canon)
+            && dest_canon.starts_with(&target_canon)
         {
             return Err("Cannot move a folder into itself".to_string());
         }
@@ -488,7 +496,8 @@ impl App {
                     return Ok(());
                 };
                 let moved = dest_dir.join(name);
-                if moved.exists() {
+                // symlink_metadata also catches dangling symlinks, which exists() misses.
+                if fs::symlink_metadata(&moved).is_ok() {
                     self.set_status("Destination already has an item with that name");
                     return Ok(());
                 }
@@ -505,10 +514,14 @@ impl App {
                     }
                     self.expanded.insert(dir.to_path_buf());
                 }
+                let prev_selected = self.selected;
                 self.rebuild_tree()?;
-                if let Some(idx) = self.tree.iter().position(|i| i.path == moved) {
-                    self.selected = idx;
-                }
+                // Select the moved item; if it left the project, stay near where we were.
+                self.selected = self
+                    .tree
+                    .iter()
+                    .position(|i| i.path == moved)
+                    .unwrap_or_else(|| prev_selected.min(self.tree.len().saturating_sub(1)));
                 self.set_status(format!(
                     "Moved {} to {}",
                     name.to_string_lossy(),
@@ -752,7 +765,7 @@ mod tests {
     #[test]
     fn move_file_into_subdir_retargets_tab_and_selects_it() {
         let tmp = tempdir().expect("tempdir");
-        let root = tmp.path().canonicalize().expect("canon root");
+        let root = tmp.path().to_path_buf();
         let file = root.join("a.rs");
         fs::write(&file, "fn a() {}\n").expect("write a");
         fs::create_dir_all(root.join("src/app")).expect("create dirs");
@@ -780,7 +793,7 @@ mod tests {
     #[test]
     fn move_rejects_folder_into_itself_and_missing_destination() {
         let tmp = tempdir().expect("tempdir");
-        let root = tmp.path().canonicalize().expect("canon root");
+        let root = tmp.path().to_path_buf();
         let dir = root.join("pkg");
         fs::create_dir_all(dir.join("inner")).expect("create dirs");
         let mut app = new_app(&root);
@@ -817,7 +830,7 @@ mod tests {
     #[test]
     fn move_rejects_name_collision_and_allows_leaving_project() {
         let tmp = tempdir().expect("tempdir");
-        let base = tmp.path().canonicalize().expect("canon");
+        let base = tmp.path().to_path_buf();
         let root = base.join("proj");
         let outside = base.join("outside");
         fs::create_dir_all(root.join("dst")).expect("create");
@@ -845,6 +858,7 @@ mod tests {
         .expect("move outside");
         assert!(outside.join("x.txt").exists());
         assert!(!root.join("x.txt").exists());
+        assert!(app.selected < app.tree.len());
     }
 
     #[test]

--- a/src/app/file_tree.rs
+++ b/src/app/file_tree.rs
@@ -20,6 +20,38 @@ impl App {
         }
     }
 
+    /// Resolve the user-entered destination folder for a move. Relative paths
+    /// are taken from the project root; absolute paths are allowed so items can
+    /// leave the project. Returns the canonical destination directory.
+    fn resolve_move_destination(&self, target: &Path, value: &str) -> Result<PathBuf, String> {
+        let trimmed = value.trim();
+        let raw = if trimmed.is_empty() || trimmed == "." {
+            self.root.clone()
+        } else {
+            self.root.join(trimmed)
+        };
+        let dest = raw
+            .canonicalize()
+            .map_err(|_| "Destination folder does not exist".to_string())?;
+        if !dest.is_dir() {
+            return Err("Destination is not a folder".to_string());
+        }
+        let current_parent = target
+            .parent()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| self.root.clone());
+        if dest == current_parent {
+            return Err("Already in that folder".to_string());
+        }
+        if target.is_dir()
+            && let Ok(target_canon) = target.canonicalize()
+            && dest.starts_with(&target_canon)
+        {
+            return Err("Cannot move a folder into itself".to_string());
+        }
+        Ok(dest)
+    }
+
     fn close_tabs_for_path_prefix(&mut self, path: &Path) {
         let mut indices: Vec<usize> = self
             .tabs
@@ -443,6 +475,46 @@ impl App {
                     relative_path(&self.root, &renamed).display()
                 ));
             }
+            PromptMode::Move { target } => {
+                let dest_dir = match self.resolve_move_destination(&target, &value) {
+                    Ok(dir) => dir,
+                    Err(msg) => {
+                        self.set_status(msg);
+                        return Ok(());
+                    }
+                };
+                let Some(name) = target.file_name() else {
+                    self.set_status("Cannot move root");
+                    return Ok(());
+                };
+                let moved = dest_dir.join(name);
+                if moved.exists() {
+                    self.set_status("Destination already has an item with that name");
+                    return Ok(());
+                }
+                if let Err(err) = fs::rename(&target, &moved) {
+                    self.set_status(format!("Move failed: {err}"));
+                    return Ok(());
+                }
+                self.retarget_tabs_for_rename(&target, &moved);
+                self.retarget_expanded_for_rename(&target, &moved);
+                // Reveal the destination: expand every ancestor inside the project.
+                for dir in dest_dir.ancestors() {
+                    if dir == self.root || !dir.starts_with(&self.root) {
+                        break;
+                    }
+                    self.expanded.insert(dir.to_path_buf());
+                }
+                self.rebuild_tree()?;
+                if let Some(idx) = self.tree.iter().position(|i| i.path == moved) {
+                    self.selected = idx;
+                }
+                self.set_status(format!(
+                    "Moved {} to {}",
+                    name.to_string_lossy(),
+                    relative_path(&self.root, &dest_dir).display()
+                ));
+            }
             PromptMode::FindInFile => {
                 self.search_in_open_file(&value);
                 if self.replace_after_find && !value.is_empty() {
@@ -547,6 +619,21 @@ impl App {
                     value: default_name,
                     cursor,
                     mode: PromptMode::Rename { target },
+                });
+            }
+            ContextAction::Move => {
+                if target == self.root {
+                    self.set_status("Cannot move project root");
+                    return Ok(());
+                }
+                let parent = target.parent().unwrap_or(&self.root);
+                let default_dir = relative_path(&self.root, parent).display().to_string();
+                let cursor = default_dir.len();
+                self.prompt = Some(PromptState {
+                    title: "Move to folder (relative to project root)".to_string(),
+                    value: default_dir,
+                    cursor,
+                    mode: PromptMode::Move { target },
                 });
             }
             ContextAction::Delete => {
@@ -660,6 +747,104 @@ mod tests {
         assert!(app.tabs.iter().any(|t| t.path == new_b));
         assert!(!app.tabs.iter().any(|t| t.path == old_a));
         assert!(!app.tabs.iter().any(|t| t.path == old_b));
+    }
+
+    #[test]
+    fn move_file_into_subdir_retargets_tab_and_selects_it() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canon root");
+        let file = root.join("a.rs");
+        fs::write(&file, "fn a() {}\n").expect("write a");
+        fs::create_dir_all(root.join("src/app")).expect("create dirs");
+
+        let mut app = new_app(&root);
+        app.open_file(file.clone()).expect("open a");
+
+        app.apply_prompt(
+            PromptMode::Move {
+                target: file.clone(),
+            },
+            "src/app".to_string(),
+        )
+        .expect("move file");
+
+        let moved = root.join("src/app/a.rs");
+        assert!(moved.exists());
+        assert!(!file.exists());
+        assert!(app.tabs.iter().any(|t| t.path == moved));
+        assert!(app.expanded.contains(&root.join("src/app")));
+        assert_eq!(app.tree[app.selected].path, moved);
+        assert_eq!(app.status, "Moved a.rs to src/app");
+    }
+
+    #[test]
+    fn move_rejects_folder_into_itself_and_missing_destination() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canon root");
+        let dir = root.join("pkg");
+        fs::create_dir_all(dir.join("inner")).expect("create dirs");
+        let mut app = new_app(&root);
+
+        app.apply_prompt(
+            PromptMode::Move {
+                target: dir.clone(),
+            },
+            "pkg/inner".to_string(),
+        )
+        .expect("non-fatal");
+        assert_eq!(app.status, "Cannot move a folder into itself");
+        assert!(dir.is_dir());
+
+        app.apply_prompt(
+            PromptMode::Move {
+                target: dir.clone(),
+            },
+            "nowhere".to_string(),
+        )
+        .expect("non-fatal");
+        assert_eq!(app.status, "Destination folder does not exist");
+
+        app.apply_prompt(
+            PromptMode::Move {
+                target: dir.clone(),
+            },
+            ".".to_string(),
+        )
+        .expect("non-fatal");
+        assert_eq!(app.status, "Already in that folder");
+    }
+
+    #[test]
+    fn move_rejects_name_collision_and_allows_leaving_project() {
+        let tmp = tempdir().expect("tempdir");
+        let base = tmp.path().canonicalize().expect("canon");
+        let root = base.join("proj");
+        let outside = base.join("outside");
+        fs::create_dir_all(root.join("dst")).expect("create");
+        fs::create_dir_all(&outside).expect("create");
+        fs::write(root.join("x.txt"), "1").expect("write");
+        fs::write(root.join("dst/x.txt"), "2").expect("write");
+        let mut app = new_app(&root);
+
+        app.apply_prompt(
+            PromptMode::Move {
+                target: root.join("x.txt"),
+            },
+            "dst".to_string(),
+        )
+        .expect("non-fatal");
+        assert_eq!(app.status, "Destination already has an item with that name");
+        assert!(root.join("x.txt").exists());
+
+        app.apply_prompt(
+            PromptMode::Move {
+                target: root.join("x.txt"),
+            },
+            outside.display().to_string(),
+        )
+        .expect("move outside");
+        assert!(outside.join("x.txt").exists());
+        assert!(!root.join("x.txt").exists());
     }
 
     #[test]

--- a/src/app/file_tree.rs
+++ b/src/app/file_tree.rs
@@ -497,9 +497,16 @@ impl App {
                 };
                 let moved = dest_dir.join(name);
                 // symlink_metadata also catches dangling symlinks, which exists() misses.
-                if fs::symlink_metadata(&moved).is_ok() {
-                    self.set_status("Destination already has an item with that name");
-                    return Ok(());
+                match fs::symlink_metadata(&moved) {
+                    Ok(_) => {
+                        self.set_status("Destination already has an item with that name");
+                        return Ok(());
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                    Err(err) => {
+                        self.set_status(format!("Cannot check destination: {err}"));
+                        return Ok(());
+                    }
                 }
                 if let Err(err) = fs::rename(&target, &moved) {
                     self.set_status(format!("Move failed: {err}"));

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,7 @@ pub(crate) enum PromptMode {
     NewFile { parent: PathBuf },
     NewFolder { parent: PathBuf },
     Rename { target: PathBuf },
+    Move { target: PathBuf },
     FindInFile,
     FindInProject,
     ReplaceInFile { search: String },
@@ -56,6 +57,7 @@ pub(crate) enum ContextAction {
     NewFile,
     NewFolder,
     Rename,
+    Move,
     Delete,
     Cancel,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -743,6 +743,25 @@ pub(crate) fn collect_all_files(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
+/// Resolve `.` and `..` components without touching the filesystem, so the
+/// result stays comparable with other non-canonical paths (e.g. the project root).
+pub(crate) fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                // Above an absolute root, `..` is a no-op; for relative paths keep it.
+                if !out.pop() && !out.has_root() {
+                    out.push(comp);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 pub(crate) fn relative_path(root: &Path, path: &Path) -> PathBuf {
     path.strip_prefix(root).unwrap_or(path).to_path_buf()
 }
@@ -750,6 +769,28 @@ pub(crate) fn relative_path(root: &Path, path: &Path) -> PathBuf {
 pub(crate) fn to_u16_saturating(v: usize) -> u16 {
     u16::try_from(v).unwrap_or(u16::MAX)
 }
+#[cfg(test)]
+mod path_tests {
+    use super::normalize_lexically;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn normalize_lexically_resolves_dots_without_fs() {
+        assert_eq!(
+            normalize_lexically(Path::new("/var/proj/./src/../lib")),
+            PathBuf::from("/var/proj/lib")
+        );
+        assert_eq!(
+            normalize_lexically(Path::new("/a/b/../../..")),
+            PathBuf::from("/")
+        );
+        assert_eq!(
+            normalize_lexically(Path::new("rel/./x/..")),
+            PathBuf::from("rel")
+        );
+    }
+}
+
 #[cfg(test)]
 mod git_parsing_tests {
     use super::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -68,12 +68,13 @@ pub(crate) fn command_action_label(action: CommandAction) -> &'static str {
     }
 }
 
-pub(crate) fn context_actions() -> [ContextAction; 6] {
+pub(crate) fn context_actions() -> [ContextAction; 7] {
     [
         ContextAction::Open,
         ContextAction::NewFile,
         ContextAction::NewFolder,
         ContextAction::Rename,
+        ContextAction::Move,
         ContextAction::Delete,
         ContextAction::Cancel,
     ]
@@ -95,6 +96,7 @@ pub(crate) fn context_label(action: ContextAction) -> &'static str {
         ContextAction::NewFile => "New File",
         ContextAction::NewFolder => "New Folder",
         ContextAction::Rename => "Rename",
+        ContextAction::Move => "Move to...",
         ContextAction::Delete => "Delete",
         ContextAction::Cancel => "Cancel",
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -751,9 +751,15 @@ pub(crate) fn normalize_lexically(path: &Path) -> PathBuf {
         match comp {
             std::path::Component::CurDir => {}
             std::path::Component::ParentDir => {
-                // Above an absolute root, `..` is a no-op; for relative paths keep it.
-                if !out.pop() && !out.has_root() {
-                    out.push(comp);
+                // Only a normal component can be cancelled. Above an absolute
+                // root `..` is a no-op; leading `..` on a relative path accumulate.
+                match out.components().next_back() {
+                    Some(std::path::Component::Normal(_)) => {
+                        out.pop();
+                    }
+                    Some(std::path::Component::RootDir) | Some(std::path::Component::Prefix(_)) => {
+                    }
+                    _ => out.push(comp),
                 }
             }
             other => out.push(other),
@@ -787,6 +793,14 @@ mod path_tests {
         assert_eq!(
             normalize_lexically(Path::new("rel/./x/..")),
             PathBuf::from("rel")
+        );
+        assert_eq!(
+            normalize_lexically(Path::new("../../x")),
+            PathBuf::from("../../x")
+        );
+        assert_eq!(
+            normalize_lexically(Path::new("a/../../b")),
+            PathBuf::from("../b")
         );
     }
 }


### PR DESCRIPTION
## Summary
Closes #12.

Adds **Move to...** between Rename and Delete in the file tree context menu. It prompts for a destination folder, pre-filled with the item's current folder relative to the project root. Absolute paths are accepted so items can leave the project (same filesystem, per the issue).

Guards: refuses moving the project root, moving a folder into itself, and name collisions at the destination (including dangling symlinks). Open tabs and expanded folders are retargeted, every ancestor of the destination is expanded so the moved item is revealed and selected, and selection stays nearby if the item leaves the tree.

The destination is normalized lexically rather than canonicalized so path comparisons keep working when the project root sits behind a symlink (macOS `/var` → `/private/var`). The tests use the raw temp path to cover exactly that case.

Not in scope: cross-device moves. `fs::rename` errors are surfaced in the status bar rather than crashing.

## Review
Tier 1. Local gate green (fmt, clippy `-D warnings`, 276 tests). Codex round 1 found the symlinked-root comparison bug, the dangling-symlink miss, and the selection reset; all fixed in the second commit. Waived: non-atomic exists-then-rename race (TUI, single user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)