### PR TITLE
Visual polish: rounded borders, shared divider, popup shadows, themed git colors (0.3.88)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           cd tap
 
           sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/lazyide.rb
-          sed -i "s|releases/download/v[^/]*/|releases/download/v${VERSION}/|g" Formula/lazyide.rb
+          sed -i "s|github.com/[^/]*/lazyide/releases/download/v[^/]*/|github.com/TysonLabs/lazyide/releases/download/v${VERSION}/|g" Formula/lazyide.rb
           sed -i "/lazyide-macos-aarch64.tar.gz/{n;s/sha256 \".*\"/sha256 \"${AARCH64_HASH}\"/;}" Formula/lazyide.rb
           sed -i "/lazyide-macos-x86_64.tar.gz/{n;s/sha256 \".*\"/sha256 \"${X86_64_HASH}\"/;}" Formula/lazyide.rb
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Add syntax highlighting and bracket pair colors for a polished experience:
 ### Tips
 
 - Look at existing themes in `themes/` for reference
-- Extra color fields (like `red`, `green`, `blue`, `orange`, etc.) are ignored but welcome for future use
+- `red`, `green`, and `yellow` (or a `terminal` block with the same keys) color the git gutter markers and tree file status; other extra color fields (`blue`, `orange`, etc.) are ignored but welcome for future use
 - All hex color values must be 6-digit with `#` prefix (e.g. `#ff00aa`)
 
 ## Bug Reports

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazyide"
-version = "0.3.87"
+version = "0.3.88"
 dependencies = [
  "arboard",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazyide"
-version = "0.3.87"
+version = "0.3.88"
 edition = "2024"
 
 [dependencies]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,25 +74,29 @@ Inside `handle_editor_key()`, editor-scoped keybinds are checked before falling 
 
 ```
 1. Layout         3-row vertical: top bar | main content | status bar
-2. Main split     If file tree open: [tree | divider | editor], else [editor]
+2. Main split     If file tree open: [tree | editor], else [editor]. The editor's
+                  left border doubles as the draggable divider and is redrawn
+                  with ┬/┴ junctions in the focused pane's color.
 3. Top bar        "lazyide  root: ...  file: ...  git: branch  Δ: ~M +A ?U"
                   Git change summary shown when repo has uncommitted changes
 4. File tree      ListWidget with TreeItem names, indent by depth
-                  Files colored by git status (modified=yellow, added=green,
+                  Files colored by git status (theme git_modified/git_added,
                   untracked=muted), directories inherit highest child status
 5. Tab bar        Horizontal tab names with click rects, [x] close buttons
-6. Editor         Line-by-line rendering (11-char gutter):
-                    - Line number (5 chars + space)
+6. Editor         Line-by-line rendering inside a 1-char horizontal padding
+                  (App::editor_inner_rect), 11-char gutter:
+                    - Line number (5 chars)
                     - Fold indicator (triangle, 2 chars)
                     - Diagnostic marker (colored dot, 1 char)
-                    - Git marker (+/~/-, 1 char, colored green/yellow/red)
-                    - Space separator (1 char)
+                    - Git marker (+/~/-, 1 char, theme git_added/modified/deleted)
+                    - Gutter separator │ + space (2 chars)
                     - Syntax-highlighted text with indent guides (│ at 4-space tab stops)
                     - Horizontal scroll clipping (when word wrap off, via clip_spans_by_columns)
                     - Cursor row highlight, selection highlight
                     - Fold summary ("... [N lines]")
 7. Status bar     Dynamic keybind hints + status message + cursor position
 8. Overlays       Modals rendered last (on top): menus, prompts, help, etc.
+                  Each gets a 1-cell drop shadow (helpers::clear_with_shadow).
 ```
 
 ## LSP Integration
@@ -113,7 +117,7 @@ Themes are JSON files with color definitions. Loading priority:
 2. System paths (`/opt/homebrew/share/lazyide/themes/`, etc.)
 3. Embedded themes via `include_dir!("$CARGO_MANIFEST_DIR/themes")` (fallback, always available)
 
-Each theme defines: background, foreground, accent, selection, border colors + syntax colors (comment, string, number, tag, attribute) + bracket pair colors (yellow, purple, cyan).
+Each theme defines: background, foreground, accent, selection, border colors + syntax colors (comment, string, number, tag, attribute) + bracket pair colors (yellow, purple, cyan) + git colors (green/yellow/red from `colors`, falling back to the `terminal` palette, then ANSI defaults).
 
 ## Syntax Highlighting
 
@@ -145,7 +149,7 @@ cargo test keybind      # tests matching "keybind"
 cargo test syntax       # tests matching "syntax"
 ```
 
-276 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
+278 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
 
 ## Adding a New Feature
 

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -30,6 +30,8 @@ use crate::util::{
 impl App {
     pub(crate) const INLINE_GHOST_MIN_PREFIX: usize = 3;
     pub(crate) const EDITOR_GUTTER_WIDTH: u16 = 11;
+    /// Horizontal padding inside the editor border, each side.
+    pub(crate) const EDITOR_PAD_X: u16 = 1;
     pub(crate) const MIN_FILES_PANE_WIDTH: u16 = 18;
     pub(crate) const MIN_EDITOR_PANE_WIDTH: u16 = 28;
     pub(crate) const FS_REFRESH_DEBOUNCE_MS: u64 = 120;
@@ -726,8 +728,19 @@ impl App {
         }
     }
 
+    /// Content area of the editor: inside the border and horizontal padding.
+    pub(crate) fn editor_inner_rect(&self) -> Rect {
+        let r = self.editor_rect;
+        Rect::new(
+            r.x.saturating_add(1 + Self::EDITOR_PAD_X),
+            r.y.saturating_add(1),
+            r.width.saturating_sub(2 + 2 * Self::EDITOR_PAD_X),
+            r.height.saturating_sub(2),
+        )
+    }
+
     fn editor_wrap_width_chars(&self) -> usize {
-        let inner_width = self.editor_rect.width.saturating_sub(2);
+        let inner_width = self.editor_inner_rect().width;
         let content_width = inner_width.saturating_sub(Self::EDITOR_GUTTER_WIDTH);
         if content_width == 0 {
             usize::MAX

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -1081,7 +1081,7 @@ mod tests {
         app.open_file(file).expect("open");
         app.word_wrap = true;
         // Simulate a narrow editor (wrap_width ~ 10 chars)
-        app.editor_rect = Rect::new(0, 0, 22, 20); // 22 - 2 border - 10 gutter = 10
+        app.editor_rect = Rect::new(0, 0, 22, 20); // 22 - 2 border - 2 padding - 11 gutter = 7 content columns
         app.rebuild_visible_rows();
         let tab = app.active_tab().expect("tab");
         // The long line should produce multiple segments (source row 0 appears more than once)

--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -566,9 +566,8 @@ impl App {
         };
         let (cursor_row, cursor_col) = tab.editor.cursor();
         let content_width = self
-            .editor_rect
+            .editor_inner_rect()
             .width
-            .saturating_sub(2)
             .saturating_sub(Self::EDITOR_GUTTER_WIDTH) as usize;
         if content_width == 0 {
             return;
@@ -741,8 +740,9 @@ impl App {
             return None;
         }
         let tab = self.active_tab()?;
-        let inner_x = x.saturating_sub(self.editor_rect.x.saturating_add(1)) as usize;
-        let inner_y = y.saturating_sub(self.editor_rect.y.saturating_add(1)) as usize;
+        let inner = self.editor_inner_rect();
+        let inner_x = x.saturating_sub(inner.x) as usize;
+        let inner_y = y.saturating_sub(inner.y) as usize;
         let lines = tab.editor.lines();
         if lines.is_empty() {
             return Some((0, 0));

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -195,7 +195,8 @@ impl App {
                         let desired = mouse.column.saturating_sub(self.tree_rect.x);
                         self.files_pane_width = desired.max(Self::MIN_FILES_PANE_WIDTH);
                         self.clamp_files_pane_width(
-                            self.editor_rect.width + self.tree_rect.width + self.divider_rect.width,
+                            // The divider column lives inside editor_rect now.
+                            self.editor_rect.width + self.tree_rect.width,
                         );
                         return Ok(());
                     }
@@ -297,9 +298,7 @@ impl App {
             match mouse.kind {
                 MouseEventKind::Down(MouseButton::Left) => {
                     self.focus = Focus::Editor;
-                    let inner_x = mouse
-                        .column
-                        .saturating_sub(self.editor_rect.x.saturating_add(1));
+                    let inner_x = mouse.column.saturating_sub(self.editor_inner_rect().x);
                     if inner_x < Self::EDITOR_GUTTER_WIDTH {
                         if inner_x < 5 {
                             // Line number area → select full line

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -301,7 +301,7 @@ impl App {
                         .column
                         .saturating_sub(self.editor_rect.x.saturating_add(1));
                     if inner_x < Self::EDITOR_GUTTER_WIDTH {
-                        if inner_x < 6 {
+                        if inner_x < 5 {
                             // Line number area → select full line
                             if let Some(row) = self.gutter_row_from_mouse(mouse.row) {
                                 self.select_line(row);

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -394,6 +394,9 @@ mod syntax_and_lang_tests {
             bracket_1: Color::Rgb(210, 168, 75),
             bracket_2: Color::Rgb(176, 82, 204),
             bracket_3: Color::Rgb(0, 175, 215),
+            git_added: Color::Green,
+            git_modified: Color::Yellow,
+            git_deleted: Color::Red,
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -124,6 +124,9 @@ pub(crate) struct Theme {
     pub(crate) bracket_1: Color,
     pub(crate) bracket_2: Color,
     pub(crate) bracket_3: Color,
+    pub(crate) git_added: Color,
+    pub(crate) git_modified: Color,
+    pub(crate) git_deleted: Color,
 }
 
 #[derive(Debug, Deserialize)]
@@ -134,6 +137,8 @@ pub(crate) struct ThemeFile {
     pub(crate) colors: ThemeColors,
     #[serde(default)]
     pub(crate) syntax: Option<ThemeSyntaxColors>,
+    #[serde(default)]
+    pub(crate) terminal: Option<ThemeTerminalColors>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -155,6 +160,21 @@ pub(crate) struct ThemeColors {
     pub(crate) purple: Option<String>,
     #[serde(default)]
     pub(crate) cyan: Option<String>,
+    #[serde(default)]
+    pub(crate) red: Option<String>,
+    #[serde(default)]
+    pub(crate) green: Option<String>,
+}
+
+/// Optional ANSI-style palette; used as a fallback source for git colors.
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct ThemeTerminalColors {
+    #[serde(default)]
+    pub(crate) red: Option<String>,
+    #[serde(default)]
+    pub(crate) green: Option<String>,
+    #[serde(default)]
+    pub(crate) yellow: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -186,8 +206,37 @@ pub(crate) fn color_from_hex(input: &str, fallback: Color) -> Color {
     fallback
 }
 
+/// First hex value that parses wins; otherwise `fallback`.
+fn first_color(candidates: [Option<&String>; 2], fallback: Color) -> Color {
+    candidates
+        .into_iter()
+        .flatten()
+        .map(|c| color_from_hex(c, fallback))
+        .find(|c| *c != fallback)
+        .unwrap_or(fallback)
+}
+
 pub(crate) fn theme_from_file(tf: ThemeFile) -> Theme {
     let syn = tf.syntax.as_ref();
+    let term = tf.terminal.as_ref();
+    let git_added = first_color(
+        [
+            tf.colors.green.as_ref(),
+            term.and_then(|t| t.green.as_ref()),
+        ],
+        Color::Green,
+    );
+    let git_modified = first_color(
+        [
+            tf.colors.yellow.as_ref(),
+            term.and_then(|t| t.yellow.as_ref()),
+        ],
+        Color::Yellow,
+    );
+    let git_deleted = first_color(
+        [tf.colors.red.as_ref(), term.and_then(|t| t.red.as_ref())],
+        Color::Red,
+    );
     let border_color = color_from_hex(&tf.colors.border, make_color(127, 122, 88));
     let fg_muted = color_from_hex(&tf.colors.foreground_muted, make_color(100, 100, 120));
     Theme {
@@ -251,6 +300,9 @@ pub(crate) fn theme_from_file(tf: ThemeFile) -> Theme {
             .map_or(make_color(0, 175, 215), |c| {
                 color_from_hex(c, make_color(0, 175, 215))
             }),
+        git_added,
+        git_modified,
+        git_deleted,
     }
 }
 
@@ -402,6 +454,27 @@ mod theme_and_persistence_tests {
         assert_eq!(theme.syntax_number, Color::Rgb(255, 158, 100));
         assert_eq!(theme.syntax_tag, Color::Rgb(122, 162, 247));
         assert_eq!(theme.syntax_attribute, Color::Rgb(115, 218, 202));
+    }
+
+    #[test]
+    fn test_git_colors_prefer_colors_then_terminal_then_ansi() {
+        let base = r##""name":"G","type":"dark","colors":{"background":"#000000","backgroundAlt":"#000000","foreground":"#ffffff","foregroundMuted":"#888888","border":"#444444","accent":"#00ff00","selection":"#333333""##;
+        // colors.* wins over terminal.*
+        let json = format!(
+            r##"{{{base},"green":"#11aa11","yellow":"#aaaa11"}},"terminal":{{"green":"#22bb22","red":"#bb2222"}}}}"##
+        );
+        let theme = theme_from_file(serde_json::from_str(&json).unwrap());
+        assert_eq!(theme.git_added, Color::Rgb(0x11, 0xaa, 0x11));
+        assert_eq!(theme.git_modified, Color::Rgb(0xaa, 0xaa, 0x11));
+        // red only in terminal
+        assert_eq!(theme.git_deleted, Color::Rgb(0xbb, 0x22, 0x22));
+
+        // neither section → ANSI defaults (previous hardcoded behavior)
+        let json = format!("{{{base}}}}}");
+        let theme = theme_from_file(serde_json::from_str(&json).unwrap());
+        assert_eq!(theme.git_added, Color::Green);
+        assert_eq!(theme.git_modified, Color::Yellow);
+        assert_eq!(theme.git_deleted, Color::Red);
     }
 
     #[test]

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear};
 
@@ -61,12 +61,27 @@ pub(crate) fn themed_block(theme: &Theme) -> Block<'static> {
         .border_style(Style::default().fg(theme.accent))
 }
 
+/// A darker version of `base` for drop shadows. True-color values are scaled
+/// down; palette colors fall back to a fixed dark gray.
+pub(crate) fn shadow_color(base: Color) -> Color {
+    match base {
+        Color::Rgb(r, g, b) => Color::Rgb(
+            (u16::from(r) * 3 / 5) as u8,
+            (u16::from(g) * 3 / 5) as u8,
+            (u16::from(b) * 3 / 5) as u8,
+        ),
+        _ => Color::Indexed(235),
+    }
+}
+
 /// Clear `area` for a popup and tint a 1-cell drop shadow below and to the
 /// right of it. The shadow recolors existing cells rather than blanking them,
 /// so underlying text stays faintly visible.
 pub(crate) fn clear_with_shadow(frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
     let screen = frame.area();
-    let shadow = Style::default().bg(theme.border).fg(theme.fg_muted);
+    let shadow = Style::default()
+        .bg(shadow_color(theme.bg))
+        .fg(theme.fg_muted);
     let buf = frame.buffer_mut();
     let bottom_y = area.bottom();
     if bottom_y < screen.bottom() {
@@ -267,6 +282,21 @@ pub(crate) fn apply_indent_guides(
 
 #[cfg(test)]
 mod indent_guide_tests {
+    #[test]
+    fn shadow_color_darkens_rgb_and_falls_back_for_palette() {
+        use super::shadow_color;
+        use ratatui::style::Color;
+        assert_eq!(
+            shadow_color(Color::Rgb(100, 200, 50)),
+            Color::Rgb(60, 120, 30)
+        );
+        assert_eq!(
+            shadow_color(Color::Rgb(255, 255, 255)),
+            Color::Rgb(153, 153, 153)
+        );
+        assert_eq!(shadow_color(Color::Indexed(17)), Color::Indexed(235));
+    }
+
     use super::*;
     use ratatui::style::Color;
 

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,7 +1,8 @@
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders};
+use ratatui::widgets::{Block, BorderType, Borders, Clear};
 
 use crate::theme::Theme;
 
@@ -55,8 +56,33 @@ pub(crate) fn list_item_style(selected: bool, theme: &Theme) -> Style {
 pub(crate) fn themed_block(theme: &Theme) -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .style(Style::default().bg(theme.bg_alt))
         .border_style(Style::default().fg(theme.accent))
+}
+
+/// Clear `area` for a popup and tint a 1-cell drop shadow below and to the
+/// right of it. The shadow recolors existing cells rather than blanking them,
+/// so underlying text stays faintly visible.
+pub(crate) fn clear_with_shadow(frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
+    let screen = frame.area();
+    let shadow = Style::default().bg(theme.border).fg(theme.fg_muted);
+    let buf = frame.buffer_mut();
+    let bottom_y = area.bottom();
+    if bottom_y < screen.bottom() {
+        let x_end = area.right().saturating_add(1).min(screen.right());
+        for x in area.x.saturating_add(1)..x_end {
+            buf[(x, bottom_y)].set_style(shadow);
+        }
+    }
+    let right_x = area.right();
+    if right_x < screen.right() {
+        let y_end = area.bottom().saturating_add(1).min(screen.bottom());
+        for y in area.y.saturating_add(1)..y_end {
+            buf[(right_x, y)].set_style(shadow);
+        }
+    }
+    frame.render_widget(Clear, area);
 }
 
 /// Clip spans to a horizontal window: skip `skip` display columns, then collect up to `width`

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -127,8 +127,8 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                         .add_modifier(Modifier::BOLD)
                 } else {
                     let fg = match app.git_file_statuses.get(&item.path) {
-                        Some(crate::tab::GitFileStatus::Modified) => Color::Yellow,
-                        Some(crate::tab::GitFileStatus::Added) => Color::Green,
+                        Some(crate::tab::GitFileStatus::Modified) => theme.git_modified,
+                        Some(crate::tab::GitFileStatus::Added) => theme.git_added,
                         Some(crate::tab::GitFileStatus::Untracked) => theme.fg_muted,
                         None => theme.fg,
                     };
@@ -427,9 +427,9 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
         }
         let mut spans = Vec::new();
         let line_num = if is_first_segment {
-            format!("{:>5} ", row + 1)
+            format!("{:>5}", row + 1)
         } else {
-            "      ".to_string()
+            "     ".to_string()
         };
         let line_num_style = if row == cursor_row {
             Style::default().fg(theme.accent)
@@ -484,18 +484,20 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
         };
         match git_status {
             GitLineStatus::Added => {
-                spans.push(Span::styled("+", Style::default().fg(Color::Green)));
+                spans.push(Span::styled("+", Style::default().fg(theme.git_added)));
             }
             GitLineStatus::Modified => {
-                spans.push(Span::styled("~", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("~", Style::default().fg(theme.git_modified)));
             }
             GitLineStatus::Deleted => {
-                spans.push(Span::styled("-", Style::default().fg(Color::Red)));
+                spans.push(Span::styled("-", Style::default().fg(theme.git_deleted)));
             }
             GitLineStatus::None => {
                 spans.push(Span::raw(" "));
             }
         }
+        // Gutter separator, then one space before the code.
+        spans.push(Span::styled("│", Style::default().fg(theme.border)));
         spans.push(Span::raw(" "));
         let segment_text = slice_chars(&lines_ref[row], seg_start, seg_end).replace('\t', "    ");
         let bracket_colors = [theme.bracket_1, theme.bracket_2, theme.bracket_3];

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,9 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Clear, List, ListItem, Padding, Paragraph, Wrap,
+};
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::App;
@@ -42,17 +44,16 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
         .split(size);
     let (tree_area, editor_area) = if app.files_view_open {
         app.clamp_files_pane_width(vertical[1].width);
-        let divider_w = 1;
         let main = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
                 Constraint::Length(app.files_pane_width),
-                Constraint::Length(divider_w),
                 Constraint::Min(App::MIN_EDITOR_PANE_WIDTH),
             ])
             .split(vertical[1]);
-        app.divider_rect = main[1];
-        (Some(main[0]), main[2])
+        // The divider is the editor's left border column, shared with the tree.
+        app.divider_rect = Rect::new(main[1].x, main[1].y, 1, main[1].height);
+        (Some(main[0]), main[1])
     } else {
         app.divider_rect = Rect::default();
         (None, vertical[1])
@@ -95,6 +96,7 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(theme.border)),
         );
     frame.render_widget(top, vertical[0]);
@@ -151,7 +153,9 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
             .block(
                 Block::default()
                     .title("[1]-Files")
-                    .borders(Borders::ALL)
+                    .borders(Borders::TOP | Borders::LEFT | Borders::BOTTOM)
+                    .border_type(BorderType::Rounded)
+                    .padding(Padding::horizontal(1))
                     .border_style(Style::default().fg(left_border))
                     .style(Style::default().bg(theme.bg_alt).fg(theme.fg)),
             );
@@ -172,11 +176,6 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                 Span::styled("[-]", Style::default().fg(theme.accent)),
             ]));
             frame.render_widget(btns, Rect::new(btn_x, btn_y, btn_width, 1));
-        }
-        if app.files_view_open && app.divider_rect.width > 0 {
-            let divider =
-                Paragraph::new("│").style(Style::default().fg(theme.border).bg(theme.bg_alt));
-            frame.render_widget(divider, app.divider_rect);
         }
     }
 
@@ -217,15 +216,33 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
     let editor_block = Block::default()
         .title(tab_title)
         .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(right_border))
         .style(Style::default().bg(theme.bg_alt).fg(theme.fg));
     frame.render_widget(editor_block, editor_area);
-    let inner = Rect::new(
-        editor_area.x.saturating_add(1),
-        editor_area.y.saturating_add(1),
-        editor_area.width.saturating_sub(2),
-        editor_area.height.saturating_sub(2),
-    );
+    if app.files_view_open && app.divider_rect.width > 0 {
+        // Redraw the shared border column as a proper split: T-junctions at the
+        // top and bottom, colored for whichever pane has focus.
+        let color = if app.focus == Focus::Tree {
+            theme.accent
+        } else {
+            right_border
+        };
+        let d = app.divider_rect;
+        let style = Style::default().fg(color).bg(theme.bg_alt);
+        let buf = frame.buffer_mut();
+        for y in d.y..d.bottom() {
+            let sym = if y == d.y {
+                "┬"
+            } else if y + 1 == d.bottom() {
+                "┴"
+            } else {
+                "│"
+            };
+            buf[(d.x, y)].set_symbol(sym).set_style(style);
+        }
+    }
+    let inner = app.editor_inner_rect();
 
     // Compute tab_rects for click detection (position within the title bar)
     {
@@ -701,6 +718,7 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
     .block(
         Block::default()
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(theme.border)),
     );
     frame.render_widget(status, vertical[2]);

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -2,7 +2,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Clear, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{List, ListItem, Paragraph, Wrap};
 
 use crate::app::App;
 use crate::keybinds::KeyAction;
@@ -12,13 +12,15 @@ use crate::util::{
     editor_context_label, primary_mod_label, relative_path,
 };
 
-use super::helpers::{centered_rect, help_keybind_line, list_item_style, themed_block};
+use super::helpers::{
+    centered_rect, clear_with_shadow, help_keybind_line, list_item_style, themed_block,
+};
 
 pub(crate) fn render_menu(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme().clone();
     let area = centered_rect(62, 62, frame.area());
     app.menu_rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let mut items: Vec<ListItem> = Vec::new();
     items.push(ListItem::new(Line::from(vec![
         Span::styled("Query: ", Style::default().fg(theme.fg_muted)),
@@ -55,7 +57,7 @@ pub(crate) fn render_theme_browser(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme().clone();
     let area = centered_rect(62, 70, frame.area());
     app.theme_browser_rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let list_items: Vec<ListItem> = app
         .themes
         .iter()
@@ -79,7 +81,7 @@ pub(crate) fn render_file_picker(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme().clone();
     let area = centered_rect(72, 65, frame.area());
     app.file_picker_rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(vec![
         Span::styled("Query: ", Style::default().fg(theme.fg_muted)),
@@ -117,7 +119,7 @@ pub(crate) fn render_search_results(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme().clone();
     let area = centered_rect(78, 72, frame.area());
     app.search_results_rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let list_items: Vec<ListItem> = if app.search_results.results.is_empty() {
         vec![ListItem::new(Line::from("No results"))]
     } else {
@@ -153,7 +155,7 @@ pub(crate) fn render_completion_popup(app: &mut App, frame: &mut Frame<'_>) {
     let y = app.editor_rect.y.saturating_add(2).min(max_y);
     let area = Rect::new(x, y, width, height);
     app.completion.rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let list_items: Vec<ListItem> = app
         .completion
         .items
@@ -181,7 +183,7 @@ pub(crate) fn render_completion_popup(app: &mut App, frame: &mut Frame<'_>) {
 pub(crate) fn render_keybind_editor(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme().clone();
     let area = centered_rect(72, 78, frame.area());
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let heading = Style::default()
         .fg(theme.accent)
         .add_modifier(Modifier::BOLD);
@@ -318,7 +320,7 @@ pub(crate) fn render_keybind_editor(app: &mut App, frame: &mut Frame<'_>) {
 pub(crate) fn render_help(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme();
     let area = centered_rect(78, 80, frame.area());
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, theme);
 
     let kb = &app.keybinds;
     let heading = Style::default()
@@ -563,7 +565,7 @@ pub(crate) fn render_context_menu(app: &mut App, frame: &mut Frame<'_>) {
     let y = app.context_menu.pos.1.min(max_y);
     let area = Rect::new(x, y, width, height);
     app.context_menu.rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let list_items: Vec<ListItem> = context_actions()
         .iter()
         .enumerate()
@@ -596,7 +598,7 @@ pub(crate) fn render_editor_context_menu(app: &mut App, frame: &mut Frame<'_>) {
     let y = app.editor_context_menu_pos.1.min(max_y);
     let area = Rect::new(x, y, width, height);
     app.editor_context_menu_rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let list_items: Vec<ListItem> = editor_context_actions()
         .iter()
         .enumerate()
@@ -626,7 +628,7 @@ pub(crate) fn render_prompt(app: &mut App, frame: &mut Frame<'_>) {
     let theme = app.active_theme().clone();
     let area = centered_rect(60, 20, frame.area());
     app.prompt_rect = area;
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, &theme);
     let input = Paragraph::new(value).block(
         themed_block(&theme)
             .title(title.as_str())
@@ -649,7 +651,7 @@ fn render_dialog(
     theme: &crate::theme::Theme,
     frame: &mut Frame<'_>,
 ) {
-    frame.render_widget(Clear, area);
+    clear_with_shadow(frame, area, theme);
     let body = Paragraph::new(text)
         .wrap(Wrap { trim: true })
         .style(Style::default().fg(theme.fg).bg(theme.bg_alt))


### PR DESCRIPTION
## Summary
Closes #24, #27. Closes #26.

- **Rounded borders** on every panel and popup block.
- **Shared divider.** The tree pane drops its right border; the editor's left border is the divider, redrawn with `┬`/`┴` junctions and colored for the focused pane. Drag math treats the divider as part of the editor rect.
- **Popup shadows.** Every overlay gets a 1-cell drop shadow that tints existing cells (darkened background color, dark gray on palette terminals) so text underneath stays faintly visible.
- **Inner padding.** Tree pane has 1-char horizontal padding. The editor has 1-char padding each side via `App::editor_inner_rect()`, which draw, mouse mapping, scroll sync, and wrap width all share.
- **Gutter separator.** A `│` between the gutter and code. Gutter width stays 11 by dropping the space after the line number.
- **Themed git colors.** Gutter markers and tree file status use `colors.green/yellow/red`, then the theme's `terminal` palette, then the ANSI defaults. All 32 shipped themes provide one of the two.
- Release workflow now rewrites the full owner/version prefix of Homebrew formula URLs, so an org move can't leave a stale owner behind.
- Docs updated. Version 0.3.88; merging auto-tags and releases.

Verified visually with VHS screenshots on a dark theme: corners, junctions, padding, separator, and shadow all render as intended.

## Review
Tier 2. Local gate green (fmt, clippy `-D warnings`, 278 tests, +1 new). **Codex CLI hung with no output on 4 of 7 runs in this repo tonight and could not complete this review**; the independent adversarial pass was done by the in-house code-review agent against the same hunt list (mouse/gutter off-by-one, stale inner-rect math, divider drag, buffer-index bounds on tiny terminals, wrap-width agreement, theme fallback). Result: CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)