### PR TITLE
Side-by-side git diff view with hunk and change navigation (0.3.90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,12 @@ The app is now modular (library + thin binary launcher):
   - `editor.rs` (editor ops, file open/save/close, clipboard, paging/selection helpers)
   - `file_tree.rs` (tree build/navigation/context actions)
   - `search.rs` (find/replace/project search)
+  - `git_diff.rs` (diff view keys, next/previous change jumps)
   - `lsp.rs` (LSP lifecycle, diagnostics, completion, definition handling)
 - `src/ui/mod.rs` + `src/ui/overlays.rs` + `src/ui/helpers.rs` — drawing and overlays
 - Shared domain/util modules:
   - `src/types.rs`, `src/tab.rs`, `src/tree_item.rs`
-  - `src/theme.rs`, `src/syntax.rs`, `src/persistence.rs`, `src/lsp_client.rs`, `src/keybinds.rs`, `src/util.rs`
+  - `src/theme.rs`, `src/syntax.rs`, `src/persistence.rs`, `src/lsp_client.rs`, `src/keybinds.rs`, `src/diff.rs`, `src/util.rs`
 
 Core model remains the same:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazyide"
-version = "0.3.89"
+version = "0.3.90"
 dependencies = [
  "arboard",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazyide"
-version = "0.3.89"
+version = "0.3.90"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ After installing, run `lazyide --setup` to detect and install optional tools (ru
 ### Git
 - **Gutter markers** — added `+`, modified `~`, deleted `-` per line via `git diff`
 - **File status** — tree colors files by status (modified, added, untracked) with directory propagation
-- **Branch display** — branch name and change summary in the top bar
+- **Branch display** — branch name and change summary in the status bar
+- **Diff view** — side-by-side working tree vs HEAD for the current file, hunk navigation, jump to hunk
+- **Change navigation** — `Alt+N` / `Alt+P` jump to the next / previous changed region
 
 ### Interface
 - **32 themes** — dark and light, with live preview browser
@@ -103,6 +105,7 @@ After installing, run `lazyide --setup` to detect and install optional tools (ru
 | `Ctrl+F` | Find in file |
 | `Ctrl+H` | Find and replace |
 | `Ctrl+Shift+F` | Search project (ripgrep) |
+| `Ctrl+Shift+G` / `F5` | Git diff of current file |
 | `Ctrl+N` | New file |
 | `Ctrl+R` | Refresh tree |
 | `Alt+Z` | Toggle word wrap |
@@ -128,6 +131,7 @@ After installing, run `lazyide --setup` to detect and install optional tools (ru
 | `Ctrl+A` | Select all |
 | `Shift+Alt+Down` / `Up` | Duplicate line |
 | `F3` / `Shift+F3` | Find next / previous |
+| `Alt+N` / `Alt+P` | Next / previous git change |
 | `PageUp` / `PageDown` | Scroll page |
 | `Ctrl+Home` / `Ctrl+End` | Start / end of file |
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ After installing, run `lazyide --setup` to detect and install optional tools (ru
 | `Ctrl+F` | Find in file |
 | `Ctrl+H` | Find and replace |
 | `Ctrl+Shift+F` | Search project (ripgrep) |
-| `Ctrl+Shift+G` / `F5` | Git diff of current file |
+| `F5` | Git diff of current file |
 | `Ctrl+N` | New file |
 | `Ctrl+R` | Refresh tree |
 | `Alt+Z` | Toggle word wrap |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,7 +156,7 @@ cargo test keybind      # tests matching "keybind"
 cargo test syntax       # tests matching "syntax"
 ```
 
-284 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
+285 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
 
 ## Adding a New Feature
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,12 +17,14 @@ src/
     file_tree.rs       Tree build, navigation, file create/rename/delete
     lsp.rs             LSP lifecycle, completion, diagnostics, go-to-definition
     search.rs          Find/replace in file, project search (ripgrep)
+    git_diff.rs        Diff view open/scroll/hunk keys, next/previous change jumps
   ui/
     mod.rs             Main draw() function (layout, tree pane, tab row, editor pane)
     status_bar.rs      Structured status bar (mode, branch, breadcrumbs, cursor, diagnostics)
     overlays.rs        Overlays: command palette, theme browser, help, prompts, etc.
     helpers.rs         UI utilities (centered_rect, label helpers, indent guides, horizontal span clipping)
   keybinds.rs          KeyAction enum, KeyBind, KeyBindings, JSON load/save
+  diff.rs              Unified diff -> side-by-side rows (FileDiff/DiffRow), change-jump helper
   types.rs             Focus, PendingAction, PromptMode, CommandAction enums
   tab.rs               Tab struct (incl. editor_scroll_col for horizontal scroll), FoldRange, ProjectSearchHit, GitLineStatus, GitFileStatus, GitChangeSummary
   tree_item.rs         TreeItem struct
@@ -141,6 +143,7 @@ Git status is computed by shelling out to `git` (no libgit2 dependency):
 - **File statuses**: `git status --porcelain -z` → NUL-separated parsing for safe handling of paths with spaces/special characters. Statuses propagate up to parent directories (Modified > Added > Untracked priority, matching VS Code behavior).
 - **Line statuses**: `git diff HEAD -- <file>` → unified diff hunk parsing. Falls back to `git status --porcelain` for untracked files (all lines marked Added). Stored per-tab in `Tab.git_line_status`.
 - **Change summary**: `GitChangeSummary` counts (modified/added/untracked) shown in top bar as `Δ: ~M +A ?U`.
+- **Diff view**: `diff::git_diff_for_file` runs `git diff HEAD -- <file>` (untracked files become all-added) and `parse_unified_diff` pairs removed/added runs into `DiffRow`s; `ui/overlays.rs::render_diff_view` draws them side by side with hunk headers. `app/git_diff.rs` owns the keys (n/p hunks, Enter jumps) and `Alt+N`/`Alt+P` change jumps via `diff::next_change_row` over the gutter statuses.
 - **Refresh triggers**: file open, file save, and FS change events. FS refresh uses path-aware event coalescing — only affected tabs recompute line status, with full fallback for `.git/` changes or ambiguous events.
 
 ## Testing
@@ -153,7 +156,7 @@ cargo test keybind      # tests matching "keybind"
 cargo test syntax       # tests matching "syntax"
 ```
 
-280 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
+284 tests cover keybindings, syntax detection, highlighting, folding, theme loading, LSP message parsing, git diff/status parsing, indent guides, and utilities.
 
 ## Adding a New Feature
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ pub(crate) struct GitResult {
 mod core;
 mod editor;
 mod file_tree;
+mod git_diff;
 mod input;
 mod input_handlers;
 mod lsp;
@@ -36,6 +37,16 @@ pub(crate) struct ContextMenuState {
     pub(crate) index: usize,
     pub(crate) target: Option<PathBuf>,
     pub(crate) pos: (u16, u16),
+    pub(crate) rect: Rect,
+}
+
+#[derive(Default)]
+pub(crate) struct DiffViewState {
+    pub(crate) open: bool,
+    pub(crate) path: Option<PathBuf>,
+    pub(crate) diff: crate::diff::FileDiff,
+    pub(crate) scroll: usize,
+    pub(crate) hunk_index: usize,
     pub(crate) rect: Rect,
 }
 
@@ -125,6 +136,7 @@ pub(crate) struct App {
     pub(crate) editor_drag_anchor: Option<(usize, usize)>,
     pub(crate) gutter_drag_anchor: Option<usize>,
     pub(crate) search_results: SearchResultsState,
+    pub(crate) diff_view: DiffViewState,
     pub(crate) search_results_rect: Rect,
     pub(crate) file_picker_open: bool,
     pub(crate) file_picker_query: String,

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -1,4 +1,6 @@
-use super::{App, CompletionState, ContextMenuState, KeybindEditorState, SearchResultsState};
+use super::{
+    App, CompletionState, ContextMenuState, DiffViewState, KeybindEditorState, SearchResultsState,
+};
 use ratatui::widgets::ListState;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -106,6 +108,7 @@ impl App {
                 index: 0,
             },
             search_results_rect: Rect::default(),
+            diff_view: DiffViewState::default(),
             file_picker_open: false,
             file_picker_query: String::new(),
             file_picker_results: Vec::new(),
@@ -487,6 +490,7 @@ impl App {
             CommandAction::GoToLine,
             CommandAction::Keybinds,
             CommandAction::ToggleWordWrap,
+            CommandAction::GitDiff,
         ];
         let q = self.menu_query.to_ascii_lowercase();
         self.menu_results = all
@@ -556,6 +560,7 @@ impl App {
                 self.refresh_keybind_editor_actions();
             }
             CommandAction::ToggleWordWrap => self.toggle_word_wrap(),
+            CommandAction::GitDiff => self.open_diff_view(),
         }
         Ok(())
     }

--- a/src/app/git_diff.rs
+++ b/src/app/git_diff.rs
@@ -4,7 +4,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, Mous
 use ratatui_textarea::CursorMove;
 
 use super::App;
-use crate::diff::{git_diff_for_file, next_change_row};
+use crate::diff::{DiffOutcome, git_diff_for_file, next_change_row};
 use crate::util::{inside, relative_path, to_u16_saturating};
 
 impl App {
@@ -14,9 +14,16 @@ impl App {
             self.set_status("No file open to diff");
             return;
         };
-        let Some(diff) = git_diff_for_file(&self.root, &path) else {
-            self.set_status("No changes against HEAD");
-            return;
+        let diff = match git_diff_for_file(&self.root, &path) {
+            DiffOutcome::Diff(d) => d,
+            DiffOutcome::Binary => {
+                self.set_status("Binary file changed; no text diff to show");
+                return;
+            }
+            DiffOutcome::Clean => {
+                self.set_status("No changes against HEAD");
+                return;
+            }
         };
         let rel = relative_path(&self.root, &path).display().to_string();
         let note = if self.is_dirty() {
@@ -56,6 +63,25 @@ impl App {
         }
     }
 
+    /// Clamp the scroll offset and point `hunk_index` at the hunk whose
+    /// header is at or above the top of the viewport.
+    fn diff_view_sync(&mut self) {
+        let max = self.diff_view_max_scroll();
+        if self.diff_view.scroll > max {
+            self.diff_view.scroll = max;
+        }
+        let scroll = self.diff_view.scroll;
+        if let Some(i) = self
+            .diff_view
+            .diff
+            .hunks
+            .iter()
+            .rposition(|h| h.start_row <= scroll)
+        {
+            self.diff_view.hunk_index = i;
+        }
+    }
+
     pub(crate) fn handle_diff_view_key(&mut self, key: KeyEvent) -> io::Result<()> {
         let max = self.diff_view_max_scroll();
         match key.code {
@@ -64,20 +90,30 @@ impl App {
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.diff_view.scroll = (self.diff_view.scroll + 1).min(max);
+                self.diff_view_sync();
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 self.diff_view.scroll = self.diff_view.scroll.saturating_sub(1);
+                self.diff_view_sync();
             }
             KeyCode::PageDown | KeyCode::Char(' ') => {
                 let page = self.diff_view_page();
                 self.diff_view.scroll = (self.diff_view.scroll + page).min(max);
+                self.diff_view_sync();
             }
             KeyCode::PageUp => {
                 let page = self.diff_view_page();
                 self.diff_view.scroll = self.diff_view.scroll.saturating_sub(page);
+                self.diff_view_sync();
             }
-            KeyCode::Home | KeyCode::Char('g') => self.diff_view.scroll = 0,
-            KeyCode::End | KeyCode::Char('G') => self.diff_view.scroll = max,
+            KeyCode::Home | KeyCode::Char('g') => {
+                self.diff_view.scroll = 0;
+                self.diff_view_sync();
+            }
+            KeyCode::End | KeyCode::Char('G') => {
+                self.diff_view.scroll = max;
+                self.diff_view_sync();
+            }
             KeyCode::Char('n') | KeyCode::Char(']') => {
                 let next = self.diff_view.hunk_index + 1;
                 if next < self.diff_view.diff.hunks.len() {
@@ -112,9 +148,11 @@ impl App {
         match mouse.kind {
             MouseEventKind::ScrollDown => {
                 self.diff_view.scroll = (self.diff_view.scroll + 3).min(max);
+                self.diff_view_sync();
             }
             MouseEventKind::ScrollUp => {
                 self.diff_view.scroll = self.diff_view.scroll.saturating_sub(3);
+                self.diff_view_sync();
             }
             MouseEventKind::Down(MouseButton::Left)
                 if !inside(mouse.column, mouse.row, self.diff_view.rect) =>

--- a/src/app/git_diff.rs
+++ b/src/app/git_diff.rs
@@ -1,0 +1,158 @@
+use std::io;
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use ratatui_textarea::CursorMove;
+
+use super::App;
+use crate::diff::{git_diff_for_file, next_change_row};
+use crate::util::{inside, relative_path, to_u16_saturating};
+
+impl App {
+    /// Open the side-by-side diff of the active file against HEAD.
+    pub(crate) fn open_diff_view(&mut self) {
+        let Some(path) = self.open_path().cloned() else {
+            self.set_status("No file open to diff");
+            return;
+        };
+        let Some(diff) = git_diff_for_file(&self.root, &path) else {
+            self.set_status("No changes against HEAD");
+            return;
+        };
+        let rel = relative_path(&self.root, &path).display().to_string();
+        let note = if self.is_dirty() {
+            "  (unsaved edits not included)"
+        } else {
+            ""
+        };
+        self.set_status(format!(
+            "Diff {rel}: +{} -{} in {} hunk(s){note}",
+            diff.added,
+            diff.removed,
+            diff.hunks.len()
+        ));
+        self.diff_view.path = Some(path);
+        self.diff_view.diff = diff;
+        self.diff_view.scroll = 0;
+        self.diff_view.hunk_index = 0;
+        self.diff_view.open = true;
+    }
+
+    fn diff_view_page(&self) -> usize {
+        (self.diff_view.rect.height.saturating_sub(2) as usize).max(1)
+    }
+
+    fn diff_view_max_scroll(&self) -> usize {
+        self.diff_view
+            .diff
+            .rows
+            .len()
+            .saturating_sub(self.diff_view_page())
+    }
+
+    fn diff_view_go_to_hunk(&mut self, index: usize) {
+        if let Some(h) = self.diff_view.diff.hunks.get(index) {
+            self.diff_view.hunk_index = index;
+            self.diff_view.scroll = h.start_row.min(self.diff_view_max_scroll());
+        }
+    }
+
+    pub(crate) fn handle_diff_view_key(&mut self, key: KeyEvent) -> io::Result<()> {
+        let max = self.diff_view_max_scroll();
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.diff_view.open = false;
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.diff_view.scroll = (self.diff_view.scroll + 1).min(max);
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.diff_view.scroll = self.diff_view.scroll.saturating_sub(1);
+            }
+            KeyCode::PageDown | KeyCode::Char(' ') => {
+                let page = self.diff_view_page();
+                self.diff_view.scroll = (self.diff_view.scroll + page).min(max);
+            }
+            KeyCode::PageUp => {
+                let page = self.diff_view_page();
+                self.diff_view.scroll = self.diff_view.scroll.saturating_sub(page);
+            }
+            KeyCode::Home | KeyCode::Char('g') => self.diff_view.scroll = 0,
+            KeyCode::End | KeyCode::Char('G') => self.diff_view.scroll = max,
+            KeyCode::Char('n') | KeyCode::Char(']') => {
+                let next = self.diff_view.hunk_index + 1;
+                if next < self.diff_view.diff.hunks.len() {
+                    self.diff_view_go_to_hunk(next);
+                }
+            }
+            KeyCode::Char('p') | KeyCode::Char('[') => {
+                if self.diff_view.hunk_index > 0 {
+                    let prev = self.diff_view.hunk_index - 1;
+                    self.diff_view_go_to_hunk(prev);
+                }
+            }
+            KeyCode::Enter => {
+                let target = self
+                    .diff_view
+                    .diff
+                    .hunks
+                    .get(self.diff_view.hunk_index)
+                    .map(|h| h.new_start.saturating_sub(1));
+                self.diff_view.open = false;
+                if let Some(row) = target {
+                    self.jump_editor_to_row(row);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub(crate) fn handle_diff_view_mouse(&mut self, mouse: MouseEvent) -> io::Result<()> {
+        let max = self.diff_view_max_scroll();
+        match mouse.kind {
+            MouseEventKind::ScrollDown => {
+                self.diff_view.scroll = (self.diff_view.scroll + 3).min(max);
+            }
+            MouseEventKind::ScrollUp => {
+                self.diff_view.scroll = self.diff_view.scroll.saturating_sub(3);
+            }
+            MouseEventKind::Down(MouseButton::Left)
+                if !inside(mouse.column, mouse.row, self.diff_view.rect) =>
+            {
+                self.diff_view.open = false;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Move the editor cursor to the start of the next or previous changed
+    /// region, based on the gutter's git line status.
+    pub(crate) fn jump_to_change(&mut self, forward: bool) {
+        let Some(tab) = self.active_tab() else {
+            self.set_status("No file open");
+            return;
+        };
+        let from = tab.editor.cursor().0;
+        match next_change_row(&tab.git_line_status, from, forward) {
+            Some(row) => {
+                self.jump_editor_to_row(row);
+                self.set_status(format!("Change at line {}", row + 1));
+            }
+            None => self.set_status(if forward {
+                "No more changes below"
+            } else {
+                "No more changes above"
+            }),
+        }
+    }
+
+    fn jump_editor_to_row(&mut self, row: usize) {
+        if let Some(tab) = self.active_tab_mut() {
+            tab.editor
+                .move_cursor(CursorMove::Jump(to_u16_saturating(row), 0));
+        }
+        self.focus = crate::types::Focus::Editor;
+        self.sync_editor_scroll_guess();
+    }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -34,6 +34,9 @@ impl App {
         if self.completion.open {
             return self.handle_completion_key(key);
         }
+        if self.diff_view.open {
+            return self.handle_diff_view_key(key);
+        }
         if self.search_results.open {
             return self.handle_search_results_key(key);
         }
@@ -158,6 +161,9 @@ impl App {
             return Ok(());
         }
 
+        if self.diff_view.open {
+            return self.handle_diff_view_mouse(mouse);
+        }
         if self.search_results.open {
             return self.handle_search_results_mouse(mouse);
         }

--- a/src/app/input_handlers.rs
+++ b/src/app/input_handlers.rs
@@ -468,6 +468,9 @@ impl App {
             KeyAction::SearchFiles => {
                 self.open_project_search_prompt();
             }
+            KeyAction::GitDiff => self.open_diff_view(),
+            KeyAction::GitNextChange => self.jump_to_change(true),
+            KeyAction::GitPrevChange => self.jump_to_change(false),
             KeyAction::GoToLine => {
                 self.open_go_to_line_prompt();
             }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,376 @@
+//! Unified-diff parsing into side-by-side rows for the diff view, plus small
+//! helpers for jumping between changed regions in the editor.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::tab::GitLineStatus;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiffLineKind {
+    Context,
+    Added,
+    Removed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiffLine {
+    pub(crate) kind: DiffLineKind,
+    /// 1-based line number in the old (HEAD) side, if present.
+    pub(crate) old_no: Option<usize>,
+    /// 1-based line number in the new (working tree) side, if present.
+    pub(crate) new_no: Option<usize>,
+    pub(crate) text: String,
+}
+
+/// One rendered row of the side-by-side view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DiffRow {
+    Header(String),
+    Pair {
+        left: Option<DiffLine>,
+        right: Option<DiffLine>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiffHunk {
+    /// Index into `FileDiff::rows` of this hunk's header row.
+    pub(crate) start_row: usize,
+    /// 1-based first line of the hunk in the new file.
+    pub(crate) new_start: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct FileDiff {
+    pub(crate) rows: Vec<DiffRow>,
+    pub(crate) hunks: Vec<DiffHunk>,
+    pub(crate) added: usize,
+    pub(crate) removed: usize,
+}
+
+impl FileDiff {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+
+/// Parse `git diff` output for a single file into side-by-side rows.
+/// Within a hunk, runs of removed and added lines are paired row by row;
+/// context lines appear on both sides.
+pub(crate) fn parse_unified_diff(diff: &str) -> FileDiff {
+    let mut out = FileDiff::default();
+    let mut old_no = 0usize;
+    let mut new_no = 0usize;
+    let mut in_hunk = false;
+    let mut removed: Vec<DiffLine> = Vec::new();
+    let mut added: Vec<DiffLine> = Vec::new();
+
+    fn flush(out: &mut FileDiff, removed: &mut Vec<DiffLine>, added: &mut Vec<DiffLine>) {
+        let n = removed.len().max(added.len());
+        let mut r = removed.drain(..);
+        let mut a = added.drain(..);
+        for _ in 0..n {
+            out.rows.push(DiffRow::Pair {
+                left: r.next(),
+                right: a.next(),
+            });
+        }
+    }
+
+    for line in diff.lines() {
+        if let Some(rest) = line.strip_prefix("@@") {
+            flush(&mut out, &mut removed, &mut added);
+            // @@ -a,b +c,d @@ optional context
+            let mut old_start = 0usize;
+            let mut new_start = 0usize;
+            for tok in rest.split_whitespace().take(2) {
+                if let Some(o) = tok.strip_prefix('-') {
+                    old_start = o
+                        .split(',')
+                        .next()
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0);
+                } else if let Some(nw) = tok.strip_prefix('+') {
+                    new_start = nw
+                        .split(',')
+                        .next()
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0);
+                }
+            }
+            old_no = old_start;
+            new_no = new_start;
+            in_hunk = true;
+            out.hunks.push(DiffHunk {
+                start_row: out.rows.len(),
+                new_start,
+            });
+            out.rows.push(DiffRow::Header(line.to_string()));
+            continue;
+        }
+        if !in_hunk || line.starts_with('\\') {
+            continue;
+        }
+        if let Some(text) = line.strip_prefix('-') {
+            removed.push(DiffLine {
+                kind: DiffLineKind::Removed,
+                old_no: Some(old_no),
+                new_no: None,
+                text: text.to_string(),
+            });
+            old_no += 1;
+            out.removed += 1;
+            continue;
+        }
+        if let Some(text) = line.strip_prefix('+') {
+            added.push(DiffLine {
+                kind: DiffLineKind::Added,
+                old_no: None,
+                new_no: Some(new_no),
+                text: text.to_string(),
+            });
+            new_no += 1;
+            out.added += 1;
+            continue;
+        }
+        // Context line: leading space, or an empty line from a blank source line.
+        flush(&mut out, &mut removed, &mut added);
+        let text = line.strip_prefix(' ').unwrap_or(line).to_string();
+        let ctx = DiffLine {
+            kind: DiffLineKind::Context,
+            old_no: Some(old_no),
+            new_no: Some(new_no),
+            text,
+        };
+        out.rows.push(DiffRow::Pair {
+            left: Some(ctx.clone()),
+            right: Some(ctx),
+        });
+        old_no += 1;
+        new_no += 1;
+    }
+    flush(&mut out, &mut removed, &mut added);
+    out
+}
+
+/// A diff where every line of `content` is new (untracked files).
+pub(crate) fn all_added_diff(content: &str) -> FileDiff {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut out = FileDiff {
+        rows: Vec::with_capacity(lines.len() + 1),
+        hunks: Vec::new(),
+        added: lines.len(),
+        removed: 0,
+    };
+    out.hunks.push(DiffHunk {
+        start_row: 0,
+        new_start: 1,
+    });
+    out.rows.push(DiffRow::Header(format!(
+        "@@ -0,0 +1,{} @@ (untracked)",
+        lines.len()
+    )));
+    for (i, text) in lines.iter().enumerate() {
+        out.rows.push(DiffRow::Pair {
+            left: None,
+            right: Some(DiffLine {
+                kind: DiffLineKind::Added,
+                old_no: None,
+                new_no: Some(i + 1),
+                text: (*text).to_string(),
+            }),
+        });
+    }
+    out
+}
+
+/// Diff of `file_path` against HEAD. Untracked files come back as all-added.
+/// Returns `None` when git is unavailable or the file is clean.
+pub(crate) fn git_diff_for_file(root: &Path, file_path: &Path) -> Option<FileDiff> {
+    let rel = file_path.strip_prefix(root).unwrap_or(file_path);
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["diff", "HEAD", "--"])
+        .arg(rel)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if output.status.success() && !output.stdout.is_empty() {
+        let diff = parse_unified_diff(&String::from_utf8_lossy(&output.stdout));
+        return (!diff.is_empty()).then_some(diff);
+    }
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["status", "--porcelain", "--"])
+        .arg(rel)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    let s = String::from_utf8_lossy(&status.stdout);
+    if s.trim_start().starts_with("??") {
+        let content = std::fs::read_to_string(file_path).ok()?;
+        return Some(all_added_diff(&content));
+    }
+    None
+}
+
+/// Row index of the next (or previous) start of a changed run relative to
+/// `from`, using the editor's per-line git status.
+pub(crate) fn next_change_row(
+    status: &[GitLineStatus],
+    from: usize,
+    forward: bool,
+) -> Option<usize> {
+    let is_start = |i: usize| {
+        status[i] != GitLineStatus::None && (i == 0 || status[i - 1] == GitLineStatus::None)
+    };
+    if forward {
+        ((from + 1)..status.len()).find(|&i| is_start(i))
+    } else {
+        (0..from.min(status.len())).rev().find(|&i| is_start(i))
+    }
+}
+
+/// Truncate `s` to at most `width` display columns, marking the cut with `…`.
+pub(crate) fn fit_width(s: &str, width: usize) -> String {
+    if s.width() <= width {
+        return s.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in s.chars() {
+        let cw = ch.width().unwrap_or(0);
+        if used + cw > width - 1 {
+            break;
+        }
+        out.push(ch);
+        used += cw;
+    }
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+diff --git a/f.rs b/f.rs
+index 1..2 100644
+--- a/f.rs
++++ b/f.rs
+@@ -1,4 +1,4 @@ fn head() {
+ fn a() {}
+-fn b() {}
+-fn c() {}
++fn b2() {}
+ fn d() {}
++fn e() {}
+@@ -10,2 +10,1 @@
+ x
+-y
+\\ No newline at end of file
+";
+
+    #[test]
+    fn parse_pairs_removed_and_added_runs() {
+        let d = parse_unified_diff(SAMPLE);
+        assert_eq!(d.hunks.len(), 2);
+        assert_eq!(d.added, 2);
+        assert_eq!(d.removed, 3);
+        assert_eq!(d.hunks[0].start_row, 0);
+        assert_eq!(d.hunks[0].new_start, 1);
+        // header, ctx a, pair(b,b2), pair(c,-), ctx d, pair(-,e)
+        assert!(matches!(&d.rows[0], DiffRow::Header(h) if h.starts_with("@@ -1,4 +1,4 @@")));
+        match &d.rows[2] {
+            DiffRow::Pair {
+                left: Some(l),
+                right: Some(r),
+            } => {
+                assert_eq!(
+                    (l.kind, l.old_no, l.text.as_str()),
+                    (DiffLineKind::Removed, Some(2), "fn b() {}")
+                );
+                assert_eq!(
+                    (r.kind, r.new_no, r.text.as_str()),
+                    (DiffLineKind::Added, Some(2), "fn b2() {}")
+                );
+            }
+            other => panic!("unexpected row: {other:?}"),
+        }
+        match &d.rows[3] {
+            DiffRow::Pair {
+                left: Some(l),
+                right: None,
+            } => assert_eq!(l.old_no, Some(3)),
+            other => panic!("unexpected row: {other:?}"),
+        }
+        match &d.rows[4] {
+            DiffRow::Pair {
+                left: Some(l),
+                right: Some(r),
+            } => {
+                assert_eq!(l.kind, DiffLineKind::Context);
+                assert_eq!((l.old_no, r.new_no), (Some(4), Some(3)));
+            }
+            other => panic!("unexpected row: {other:?}"),
+        }
+        match &d.rows[5] {
+            DiffRow::Pair {
+                left: None,
+                right: Some(r),
+            } => assert_eq!(r.new_no, Some(4)),
+            other => panic!("unexpected row: {other:?}"),
+        }
+        // second hunk: header, ctx, removed; the "\ No newline" marker is skipped
+        assert_eq!(d.hunks[1].start_row, 6);
+        assert_eq!(d.rows.len(), 9);
+    }
+
+    #[test]
+    fn all_added_diff_numbers_every_line() {
+        let d = all_added_diff("a\nb\n");
+        assert_eq!(d.added, 2);
+        assert_eq!(d.hunks.len(), 1);
+        assert_eq!(d.rows.len(), 3);
+        match &d.rows[2] {
+            DiffRow::Pair {
+                left: None,
+                right: Some(r),
+            } => assert_eq!((r.new_no, r.text.as_str()), (Some(2), "b")),
+            other => panic!("unexpected row: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn next_change_row_finds_run_starts_both_ways() {
+        use GitLineStatus::{Added as A, Modified as M, None as N};
+        let s = [N, A, A, N, N, M, N];
+        assert_eq!(next_change_row(&s, 0, true), Some(1));
+        assert_eq!(next_change_row(&s, 1, true), Some(5));
+        assert_eq!(next_change_row(&s, 5, true), None);
+        assert_eq!(next_change_row(&s, 6, false), Some(5));
+        assert_eq!(next_change_row(&s, 5, false), Some(1));
+        assert_eq!(next_change_row(&s, 1, false), None);
+        assert_eq!(next_change_row(&[], 0, true), None);
+        assert_eq!(next_change_row(&s, 99, false), Some(5));
+    }
+
+    #[test]
+    fn fit_width_truncates_with_ellipsis() {
+        assert_eq!(fit_width("hello", 10), "hello");
+        assert_eq!(fit_width("hello world", 6), "hello…");
+        assert_eq!(fit_width("日本語", 4), "日…");
+        assert_eq!(fit_width("abc", 0), "");
+    }
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -187,24 +187,42 @@ pub(crate) fn all_added_diff(content: &str) -> FileDiff {
     out
 }
 
-/// Diff of `file_path` against HEAD. Untracked files come back as all-added.
-/// Returns `None` when git is unavailable or the file is clean.
-pub(crate) fn git_diff_for_file(root: &Path, file_path: &Path) -> Option<FileDiff> {
+/// Result of asking git for a file's diff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DiffOutcome {
+    Diff(FileDiff),
+    /// Git reports a change but has no text hunks to show.
+    Binary,
+    /// Clean, or git unavailable.
+    Clean,
+}
+
+/// Diff of `file_path` against HEAD. Untracked (or staged-new in an unborn
+/// repository) files come back as all-added.
+pub(crate) fn git_diff_for_file(root: &Path, file_path: &Path) -> DiffOutcome {
     let rel = file_path.strip_prefix(root).unwrap_or(file_path);
     let output = Command::new("git")
         .arg("-C")
         .arg(root)
-        .args(["diff", "HEAD", "--"])
+        .args(["diff", "--no-color", "--no-ext-diff", "HEAD", "--"])
         .arg(rel)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .output()
-        .ok()?;
-    if output.status.success() && !output.stdout.is_empty() {
-        let diff = parse_unified_diff(&String::from_utf8_lossy(&output.stdout));
-        return (!diff.is_empty()).then_some(diff);
+        .output();
+    if let Ok(output) = &output
+        && output.status.success()
+        && !output.stdout.is_empty()
+    {
+        let text = String::from_utf8_lossy(&output.stdout);
+        let diff = parse_unified_diff(&text);
+        if !diff.is_empty() {
+            return DiffOutcome::Diff(diff);
+        }
+        if text.contains("Binary files") {
+            return DiffOutcome::Binary;
+        }
     }
-    let status = Command::new("git")
+    let Ok(status) = Command::new("git")
         .arg("-C")
         .arg(root)
         .args(["status", "--porcelain", "--"])
@@ -212,13 +230,19 @@ pub(crate) fn git_diff_for_file(root: &Path, file_path: &Path) -> Option<FileDif
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .output()
-        .ok()?;
+    else {
+        return DiffOutcome::Clean;
+    };
     let s = String::from_utf8_lossy(&status.stdout);
-    if s.trim_start().starts_with("??") {
-        let content = std::fs::read_to_string(file_path).ok()?;
-        return Some(all_added_diff(&content));
+    let code = s.trim_start();
+    if code.starts_with("??") || code.starts_with('A') {
+        return match std::fs::read_to_string(file_path) {
+            Ok(content) if !content.is_empty() => DiffOutcome::Diff(all_added_diff(&content)),
+            Ok(_) => DiffOutcome::Clean,
+            Err(_) => DiffOutcome::Binary,
+        };
     }
-    None
+    DiffOutcome::Clean
 }
 
 /// Row index of the next (or previous) start of a changed run relative to
@@ -350,6 +374,13 @@ index 1..2 100644
             } => assert_eq!((r.new_no, r.text.as_str()), (Some(2), "b")),
             other => panic!("unexpected row: {other:?}"),
         }
+    }
+
+    #[test]
+    fn all_added_diff_of_empty_content_has_no_lines() {
+        let d = all_added_diff("");
+        assert_eq!(d.added, 0);
+        assert_eq!(d.rows.len(), 1); // header only; callers treat empty files as clean
     }
 
     #[test]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -202,6 +202,7 @@ pub(crate) enum DiffOutcome {
 pub(crate) fn git_diff_for_file(root: &Path, file_path: &Path) -> DiffOutcome {
     let rel = file_path.strip_prefix(root).unwrap_or(file_path);
     let output = Command::new("git")
+        .env("LC_ALL", "C")
         .arg("-C")
         .arg(root)
         .args(["diff", "--no-color", "--no-ext-diff", "HEAD", "--"])
@@ -237,6 +238,7 @@ pub(crate) fn git_diff_for_file(root: &Path, file_path: &Path) -> DiffOutcome {
     let code = s.trim_start();
     if code.starts_with("??") || code.starts_with('A') {
         return match std::fs::read_to_string(file_path) {
+            Ok(content) if content.contains('\0') => DiffOutcome::Binary,
             Ok(content) if !content.is_empty() => DiffOutcome::Diff(all_added_diff(&content)),
             Ok(_) => DiffOutcome::Clean,
             Err(_) => DiffOutcome::Binary,

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -32,6 +32,7 @@ pub(crate) enum KeyAction {
     TreeCollapseAll,
     TreeExpandRecursive,
     TreeCollapseRecursive,
+    GitDiff,
     // Editor
     GoToDefinition,
     FoldToggle,
@@ -58,6 +59,8 @@ pub(crate) enum KeyAction {
     PageUp,
     GoToStart,
     GoToEnd,
+    GitNextChange,
+    GitPrevChange,
 }
 
 impl KeyAction {
@@ -84,6 +87,7 @@ impl KeyAction {
                 | KeyAction::TreeCollapseAll
                 | KeyAction::TreeExpandRecursive
                 | KeyAction::TreeCollapseRecursive
+                | KeyAction::GitDiff
         )
     }
 
@@ -102,6 +106,9 @@ impl KeyAction {
             KeyAction::Find => "Find",
             KeyAction::FindReplace => "Find & Replace",
             KeyAction::SearchFiles => "Search Files",
+            KeyAction::GitDiff => "Git Diff",
+            KeyAction::GitNextChange => "Next Change",
+            KeyAction::GitPrevChange => "Previous Change",
             KeyAction::GoToLine => "Go to Line",
             KeyAction::Help => "Help",
             KeyAction::NewFile => "New File",
@@ -163,6 +170,7 @@ impl KeyAction {
             KeyAction::TreeCollapseAll,
             KeyAction::TreeExpandRecursive,
             KeyAction::TreeCollapseRecursive,
+            KeyAction::GitDiff,
             KeyAction::GoToDefinition,
             KeyAction::FoldToggle,
             KeyAction::FoldAllToggle,
@@ -188,6 +196,8 @@ impl KeyAction {
             KeyAction::PageUp,
             KeyAction::GoToStart,
             KeyAction::GoToEnd,
+            KeyAction::GitNextChange,
+            KeyAction::GitPrevChange,
         ]
     }
 }
@@ -530,8 +540,12 @@ impl KeyBindings {
         bind(KeyAction::TreeCollapseAll, "ctrl+shift+c");
         bind(KeyAction::TreeExpandRecursive, "shift+right");
         bind(KeyAction::TreeCollapseRecursive, "shift+left");
+        bind(KeyAction::GitDiff, "ctrl+shift+g");
+        bind(KeyAction::GitDiff, "f5");
 
         // Editor
+        bind(KeyAction::GitNextChange, "alt+n");
+        bind(KeyAction::GitPrevChange, "alt+p");
         bind(KeyAction::GoToDefinition, "ctrl+d");
         bind(KeyAction::GoToDefinition, "ctrl+alt+d");
         bind(KeyAction::FoldToggle, "ctrl+j");

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -540,7 +540,6 @@ impl KeyBindings {
         bind(KeyAction::TreeCollapseAll, "ctrl+shift+c");
         bind(KeyAction::TreeExpandRecursive, "shift+right");
         bind(KeyAction::TreeCollapseRecursive, "shift+left");
-        bind(KeyAction::GitDiff, "ctrl+shift+g");
         bind(KeyAction::GitDiff, "f5");
 
         // Editor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use ratatui::crossterm::terminal::{
 };
 
 mod app;
+mod diff;
 mod keybinds;
 mod lsp_client;
 mod persistence;

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,6 +41,7 @@ pub(crate) enum CommandAction {
     GoToLine,
     Keybinds,
     ToggleWordWrap,
+    GitDiff,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -628,6 +628,9 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
     if app.search_results.open {
         render_search_results(app, frame);
     }
+    if app.diff_view.open {
+        render_diff_view(app, frame);
+    }
     if app.completion.open {
         render_completion_popup(app, frame);
     }

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -11,6 +11,7 @@ use crate::util::{
     command_action_label, context_actions, context_label, editor_context_actions,
     editor_context_label, primary_mod_label, relative_path,
 };
+use unicode_width::UnicodeWidthStr;
 
 use super::helpers::{
     centered_rect, clear_with_shadow, help_keybind_line, list_item_style, themed_block,
@@ -379,6 +380,16 @@ pub(crate) fn render_help(app: &mut App, frame: &mut Frame<'_>) {
             sep_s,
         ),
         help_keybind_line(
+            &[
+                (&kb.display_for(KeyAction::GitDiff), "git diff"),
+                (&kb.display_for(KeyAction::GitNextChange), "next change"),
+                (&kb.display_for(KeyAction::GitPrevChange), "prev change"),
+            ],
+            key_s,
+            desc_s,
+            sep_s,
+        ),
+        help_keybind_line(
             &[(
                 &kb.display_for(KeyAction::GoToDefinition),
                 "go to definition",
@@ -719,4 +730,102 @@ pub(crate) fn render_recovery_prompt(app: &mut App, frame: &mut Frame<'_>) {
     ]
     .join("\n");
     render_dialog(area, "Recover Autosave", text, theme, frame);
+}
+
+pub(crate) fn render_diff_view(app: &mut App, frame: &mut Frame<'_>) {
+    use crate::diff::{DiffLine, DiffLineKind, DiffRow, fit_width};
+
+    let theme = app.active_theme().clone();
+    let area = centered_rect(92, 86, frame.area());
+    app.diff_view.rect = area;
+    clear_with_shadow(frame, area, &theme);
+
+    let rel = app
+        .diff_view
+        .path
+        .as_ref()
+        .map(|p| relative_path(&app.root, p).display().to_string())
+        .unwrap_or_default();
+    let d = &app.diff_view.diff;
+    let title = format!(
+        " Diff vs HEAD: {rel}   +{} -{}   hunk {}/{}   n/p hunks · Enter jump · Esc close ",
+        d.added,
+        d.removed,
+        (app.diff_view.hunk_index + 1).min(d.hunks.len()),
+        d.hunks.len()
+    );
+
+    let inner_w = area.width.saturating_sub(2) as usize;
+    let inner_h = area.height.saturating_sub(2) as usize;
+    // [left half] │ [right half]
+    let half = inner_w.saturating_sub(1) / 2;
+    let right_w = inner_w.saturating_sub(1).saturating_sub(half);
+    let num_w = 5usize;
+
+    let ctx_style = Style::default().fg(theme.fg);
+    let num_style = Style::default().fg(theme.fg_muted);
+    let removed_style = Style::default().fg(theme.git_deleted);
+    let added_style = Style::default().fg(theme.git_added);
+    let header_style = Style::default()
+        .fg(theme.accent)
+        .bg(theme.selection)
+        .add_modifier(Modifier::BOLD);
+    let sep_style = Style::default().fg(theme.border);
+
+    let side = |line: Option<&DiffLine>, width: usize, new_side: bool| -> Vec<Span<'static>> {
+        let Some(l) = line else {
+            return vec![Span::raw(" ".repeat(width))];
+        };
+        let no = if new_side { l.new_no } else { l.old_no };
+        let num = no
+            .map(|n| format!("{n:>4} "))
+            .unwrap_or_else(|| " ".repeat(num_w));
+        let (marker, style) = match l.kind {
+            DiffLineKind::Added => ("+", added_style),
+            DiffLineKind::Removed => ("-", removed_style),
+            DiffLineKind::Context => (" ", ctx_style),
+        };
+        let text_w = width.saturating_sub(num_w + 1);
+        let text = fit_width(&l.text.replace('\t', "    "), text_w);
+        let pad = text_w.saturating_sub(text.width());
+        vec![
+            Span::styled(num, num_style),
+            Span::styled(marker.to_string(), style),
+            Span::styled(text, style),
+            Span::raw(" ".repeat(pad)),
+        ]
+    };
+
+    let current_hunk_row = d.hunks.get(app.diff_view.hunk_index).map(|h| h.start_row);
+    let mut lines: Vec<Line> = Vec::with_capacity(inner_h);
+    if d.rows.is_empty() {
+        lines.push(Line::from(Span::styled("No changes", num_style)));
+    }
+    for row in d.rows.iter().skip(app.diff_view.scroll).take(inner_h) {
+        match row {
+            DiffRow::Header(h) => {
+                let idx = d.rows.iter().position(|r| std::ptr::eq(r, row));
+                let mut st = header_style;
+                if idx != current_hunk_row {
+                    st = st.remove_modifier(Modifier::BOLD);
+                }
+                let text = fit_width(h, inner_w);
+                let pad = inner_w.saturating_sub(text.width());
+                lines.push(Line::from(vec![
+                    Span::styled(text, st),
+                    Span::styled(" ".repeat(pad), st),
+                ]));
+            }
+            DiffRow::Pair { left, right } => {
+                let mut spans = side(left.as_ref(), half, false);
+                spans.push(Span::styled("│", sep_style));
+                spans.extend(side(right.as_ref(), right_w, true));
+                lines.push(Line::from(spans));
+            }
+        }
+    }
+    let body = Paragraph::new(lines)
+        .style(Style::default().fg(theme.fg).bg(theme.bg_alt))
+        .block(themed_block(&theme).title(title));
+    frame.render_widget(body, area);
 }

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -760,7 +760,28 @@ pub(crate) fn render_diff_view(app: &mut App, frame: &mut Frame<'_>) {
     // [left half] │ [right half]
     let half = inner_w.saturating_sub(1) / 2;
     let right_w = inner_w.saturating_sub(1).saturating_sub(half);
-    let num_w = 5usize;
+    // Line-number column sized to the largest number present (min 4 digits).
+    let max_no = d
+        .rows
+        .iter()
+        .filter_map(|r| match r {
+            DiffRow::Pair { left, right } => Some(
+                left.as_ref()
+                    .and_then(|l| l.old_no)
+                    .max(right.as_ref().and_then(|l| l.new_no))
+                    .unwrap_or(0),
+            ),
+            DiffRow::Header(_) => None,
+        })
+        .max()
+        .unwrap_or(0);
+    let digits = max_no.to_string().len().max(4);
+    let num_w = digits + 1;
+    // Clamp a stale scroll (e.g. after a resize) without mutating state here.
+    let scroll = app
+        .diff_view
+        .scroll
+        .min(d.rows.len().saturating_sub(inner_h.max(1)));
 
     let ctx_style = Style::default().fg(theme.fg);
     let num_style = Style::default().fg(theme.fg_muted);
@@ -776,17 +797,24 @@ pub(crate) fn render_diff_view(app: &mut App, frame: &mut Frame<'_>) {
         let Some(l) = line else {
             return vec![Span::raw(" ".repeat(width))];
         };
-        let no = if new_side { l.new_no } else { l.old_no };
-        let num = no
-            .map(|n| format!("{n:>4} "))
-            .unwrap_or_else(|| " ".repeat(num_w));
         let (marker, style) = match l.kind {
             DiffLineKind::Added => ("+", added_style),
             DiffLineKind::Removed => ("-", removed_style),
             DiffLineKind::Context => (" ", ctx_style),
         };
-        let text_w = width.saturating_sub(num_w + 1);
-        let text = fit_width(&l.text.replace('\t', "    "), text_w);
+        let body = l.text.replace('\t', "    ");
+        // Too narrow for numbers: show what fits of the text alone.
+        if width < num_w + 2 {
+            let text = fit_width(&body, width);
+            let pad = width.saturating_sub(text.width());
+            return vec![Span::styled(text, style), Span::raw(" ".repeat(pad))];
+        }
+        let no = if new_side { l.new_no } else { l.old_no };
+        let num = no
+            .map(|n| format!("{n:>w$} ", w = digits))
+            .unwrap_or_else(|| " ".repeat(num_w));
+        let text_w = width - num_w - 1;
+        let text = fit_width(&body, text_w);
         let pad = text_w.saturating_sub(text.width());
         vec![
             Span::styled(num, num_style),
@@ -801,12 +829,11 @@ pub(crate) fn render_diff_view(app: &mut App, frame: &mut Frame<'_>) {
     if d.rows.is_empty() {
         lines.push(Line::from(Span::styled("No changes", num_style)));
     }
-    for row in d.rows.iter().skip(app.diff_view.scroll).take(inner_h) {
+    for (idx, row) in d.rows.iter().enumerate().skip(scroll).take(inner_h) {
         match row {
             DiffRow::Header(h) => {
-                let idx = d.rows.iter().position(|r| std::ptr::eq(r, row));
                 let mut st = header_style;
-                if idx != current_hunk_row {
+                if Some(idx) != current_hunk_row {
                     st = st.remove_modifier(Modifier::BOLD);
                 }
                 let text = fit_width(h, inner_w);

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,6 +65,7 @@ pub(crate) fn command_action_label(action: CommandAction) -> &'static str {
         CommandAction::GoToLine => "Go to Line",
         CommandAction::Keybinds => "Keybind Editor",
         CommandAction::ToggleWordWrap => "Toggle Word Wrap",
+        CommandAction::GitDiff => "Git Diff (current file)",
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -214,7 +214,7 @@ pub(crate) fn compute_git_line_status(
     let diff_output = Command::new("git")
         .arg("-C")
         .arg(root)
-        .args(["diff", "HEAD", "--"])
+        .args(["diff", "--no-color", "--no-ext-diff", "HEAD", "--"])
         .arg(rel_str.as_ref())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())


### PR DESCRIPTION
## Summary
Closes #23.

**Diff view.** `F5` or the palette entry "Git Diff (current file)" opens a side-by-side view of the active file against HEAD: old on the left, new on the right, removed and added runs aligned row by row, context on both sides, hunk headers spanning the width with the current hunk in bold. `j`/`k`/arrows, PageUp/PageDown, Home/End, and the mouse wheel scroll; `n`/`p` (or `]`/`[`) step hunks; Enter jumps the editor to the hunk and closes; Esc/`q` or a click outside closes. Untracked files render as all-added. Binary changes and clean files get clear status messages.

**Change navigation.** `Alt+N` / `Alt+P` move the cursor to the next / previous changed region using the gutter's git line status.

New module `src/diff.rs` holds the parser (`parse_unified_diff` pairs runs into `DiffRow`s), the git shell-out, and the change-jump helper, all unit tested. `src/app/git_diff.rs` owns the keys and mouse. Git is invoked with `--no-color --no-ext-diff` and `LC_ALL=C` here and in the gutter status path.

Verified with VHS: open via palette, step to hunk 3 of 7, Enter lands on line 87.

## Review
Tier 2. Local gate green (fmt, clippy `-D warnings`, 285 tests, +5 new). Round 1 ran Codex and the in-house reviewer in parallel; confirmed and fixed: hunk index went stale on scroll, binary files reported "No changes", unborn-repo staged files and empty untracked files mishandled, line-number column overflowed past 9999 lines and on very narrow panes, stale scroll after resize, quadratic header lookup, and git color/ext-diff not disabled. Codex confirmation round: two P2 nits (localized git output, NUL-containing untracked files), both fixed with one-liners.

**Dropped default:** `ctrl+shift+g` was planned as the primary key, but `KeyBind::matches` strips Shift for character keys, so it is indistinguishable from `ctrl+g` (Go to Line). `F5` is the sole default. The same collision affects the pre-existing `ctrl+shift+f/e/c/z/p/[/]` defaults; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)